### PR TITLE
Added client-string generator

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,3 @@
+health:
+    description: Call the health of the cluster
+

--- a/actions/health
+++ b/actions/health
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+PRIVATE_ADDRESS=$(unit-get private-address)
+OUT=$(/opt/etcd/etcdctl -C http://${PRIVATE_ADDRESS}:4001 cluster-health)
+
+action-set result-map.message="${OUT}"

--- a/copyright
+++ b/copyright
@@ -1,0 +1,13 @@
+Copyright 2015 Canonical LTD
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="96"
+   height="96"
+   id="svg6517"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="icon.svg">
+  <defs
+     id="defs6519">
+    <linearGradient
+       id="Background">
+      <stop
+         id="stop4178"
+         offset="0"
+         style="stop-color:#b8b8b8;stop-opacity:1" />
+      <stop
+         id="stop4180"
+         offset="1"
+         style="stop-color:#c9c9c9;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Inner Shadow"
+       id="filter1121">
+      <feFlood
+         flood-opacity="0.59999999999999998"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood1123" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="out"
+         result="composite1"
+         id="feComposite1125" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1"
+         result="blur"
+         id="feGaussianBlur1127" />
+      <feOffset
+         dx="0"
+         dy="2"
+         result="offset"
+         id="feOffset1129" />
+      <feComposite
+         in="offset"
+         in2="SourceGraphic"
+         operator="atop"
+         result="composite2"
+         id="feComposite1131" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Drop Shadow"
+       id="filter950">
+      <feFlood
+         flood-opacity="0.25"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood952" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite954" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1"
+         result="blur"
+         id="feGaussianBlur956" />
+      <feOffset
+         dx="0"
+         dy="1"
+         result="offset"
+         id="feOffset958" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite960" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath873">
+      <g
+         transform="matrix(0,-0.66666667,0.66604479,0,-258.25992,677.00001)"
+         id="g875"
+         inkscape:label="Layer 1"
+         style="fill:#ff00ff;fill-opacity:1;stroke:none;display:inline">
+        <path
+           style="fill:#ff00ff;fill-opacity:1;stroke:none;display:inline"
+           d="m 46.702703,898.22775 50.594594,0 C 138.16216,898.22775 144,904.06497 144,944.92583 l 0,50.73846 c 0,40.86071 -5.83784,46.69791 -46.702703,46.69791 l -50.594594,0 C 5.8378378,1042.3622 0,1036.525 0,995.66429 L 0,944.92583 C 0,904.06497 5.8378378,898.22775 46.702703,898.22775 Z"
+           id="path877"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+      </g>
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       id="filter891"
+       inkscape:label="Badge Shadow">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.71999962"
+         id="feGaussianBlur893" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0745362"
+     inkscape:cx="-10.435702"
+     inkscape:cy="49.020373"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     showborder="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid821" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="16,48"
+       id="guide823" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="64,80"
+       id="guide825" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="80,40"
+       id="guide827" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="64,16"
+       id="guide829" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata6522">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BACKGROUND"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(268,-635.29076)"
+     style="display:inline">
+    <path
+       style="fill:#eeeeee;fill-opacity:1;stroke:none;display:inline;filter:url(#filter1121)"
+       d="m -268,700.15563 0,-33.72973 c 0,-27.24324 3.88785,-31.13513 31.10302,-31.13513 l 33.79408,0 c 27.21507,0 31.1029,3.89189 31.1029,31.13513 l 0,33.72973 c 0,27.24325 -3.88783,31.13514 -31.1029,31.13514 l -33.79408,0 C -264.11215,731.29077 -268,727.39888 -268,700.15563 Z"
+       id="path6455"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="matt made me do this"
+     style="display:inline">
+    <image
+       width="64"
+       height="64"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGgAAABlCAYAAAChgqZ/AAAABHNCSVQICAgIfAhkiAAADkpJREFU eJztnXl0G9W9x78z2mUtlmXLsp14wUs2A4lTIOQlNJCYBJIX2iaEc/pKF2iB9rQ9CaWkdHkc+ign aUt7oOUAXVI4h8IjaU4SXiBkIYdmIQklMXZiQ7wE27G8SpYlWdZie+77A0izSKNZ7ows0Oc/ezS/ e+d+59753d/87h0gS5YsWbJkyZIlSxZJcBy36U8nBsiZ3hBJd11O9ITJS40+wnHcpnTXBQCYdBbe E4iT/z3tx972ICY4gm/Oc+Ib85xprdOTRwfI7rMBGLUsVs2w4bvX5W9mWfYn6apPWhojNj753nPv +ebvPhvABPfvTlPtNOBPd5SlVaA1r3SQ4cjkhb/1GgZfnmHDAwsK01Iv1Qvd0eInfznpw9g4l/D4 39eWo9imT0tjnBmIkB+8fj7hsVyjBg9cl4/l1XZV68aqVVDHYJg8sKuLPH18KKk4ALC9ZUS0bY7j Nm0/7SMbXu8mP93vIfvag4QQskysnVebfEmPjUQnsenwADbsOU/80fFh0ZWUiCp3w44WP3n+X17E JlP7AEYtizfurqxkGOZcqt/uaw+SPW0BNPZFcLllDcvg+hIzbq+xY1GZJeV1dvpj5J4dXVfYSYRZ x2L9jS7UV9kUbz/FC3j0gIcc6g6LOmdJWQ4eXVqSsG7nBsNk59kg3uoM8/bEi3EYNVhRY8O9dc5t GpZdl+g3P3z9PDk9EBFVz/+caceDC5V9Nilm3B8dH37wDY+jcyQu6fzHbinCTeXWC/Vr6BsjW8/4 ceJ8WNBdnggNy2BJuQXrah2oyTdesP2PZj955sSQJJtzXEb8YeV0QT1eCooIdNYbJY/s88AfnUz9 4yQYtQyerC9CDCxebPChsV/c3Z2KG6eZ8bWrczHGMdi4zwNOxgysyKrDE0tcKC/Iod6e1A02D0bI w3s9gocfPvQaBnEBzy056DQMximU4TRrsfnWYlTmGam2KVVjTf1j5OG9HkHOwGcRu1GDzbcUYoY7 tVMiFGpudqs3Sh7Z3/u5FQcAAtFJ/PztQfQE4tQagYpAnmCc2rCW6XjHJrBxnwex8cn3aNijItBI dBJWg4aGqc8EOXoWntDEfBq2qD6Dfnd0gPzf2QBNkxkFwwB3zbbj/hvozY2oe3H72oNk8+F+WW5r JmLQMHjsliLcMJ2egwAoNA862jVKHj3Yi8+Lv2DUsvjVEhfqSumHfhQJlv5HmYX5wQKXEqanJI/c VKiIOICC0ew7ZuUy9ZVWpcxfAcsAi8ssmOc2qlYmAKybbb8kJEUbxYOlX3q5gwRkhHxSYTNosGqG HWtr7X6HUZcHfByZ3vVhAG+2BRGdUM71L7Lq8PKdFYq2oVZJ4wDgtuighEA2A4u1s+y4u66A2QXg OxcdK3cYGACY5Litfz3pu3PHBwFFhCq16ajbvBxF1d+w5zx5v49ukNOgZfBf1+Th7rnichf+eHyQ 7PhghLp3uazSip99sSjzhrgH9/SQhr4xqjZvrrDi29faUZxnllTvTn+MPH1sAA39Uar1WlltxUOL lRFJEaP/83YfOXguRM1eoUWLhxcVoq6YTjj/rXNB8tSxIYRi9Iber8/Nw7fq8qf+64Zn3x0iW8/4 qdlbWWPHQ4vov7X0h6PDvz7idRz30Ovl629w4o45dNPGqBp7/WyA/PboABVbOXoWP1nsFpRPIIed H4yQZ04MXZL+JRWWAX69vATzKfV0gKJAzQMRsn5PD5ULrcjV45dLizHNrk76VZMnRB4/MoSh8IRs W1Y9i2duK8Z0p7Tn5OVQmagSQu7774O9VMRZXGbBlq+UM2qJAwDXlFiZV9dVVM4ukD/JDcU5PHZY Wn5DIqg0wkNv9pCTvfLH8tU1NmxY5E5rZulP93vIsfPispASsaraih9R8Oxk96CXm4apiHNPnTPt 4gDAE/UlzO01Ntl2dreFcLhL/mIA2QJtOemVawL3zHWInngqyY8XuZnbquWL9PQx+UOdbIHkvlL4 zvx83F1XMGXE+ZSHF7uZpVfJC/ZGKISXVMvNTsSamTZ89dq8KSfOp/x8SRFz4/Qc6QYohJUUD5Ym Y1GZBd9fyP/MaegbI9ub/Tj6SepwoUWLFVU2fFPCjL0vFCcvNgzjSPcownEOOXoWi0otWF5tw7yi 5C7xE/UlzH27ukibLya2SGg18u892RbqX2gjYt3rilw9tnylnLfsTYf6yd72YMJjOToWv799Gqqd wpIEd7cMk+dODSMcTzzk/GhBPlbNTt6T+/0R8r03e+GPiAsN0XgdIXuIM2nFl1+cIkz/wilvUnEA IDzOYcOeHvSFUueftfmi5Mnj3qTiAMCTx728HpfbYWIKzOIHG7NO/hNEtgWzXrwJvpztvlCc/EPA GqFwnMPfBHiQQpPiNx/iD1H5xsRHGaTcvJcjWyC7hHy4II9A7/dFeO/2i3mnh3/+1ReKE6FJ9+Fx Dg19Y0l7USAm3iPLNcp/xMsWKNcg3sQQz93YGxD+MA7HOfCtpOsfFXfXdyRxBDiO2yQljOUwy0/m lC1QgUUv+pzYBMEkx21NdEyjEVclhmEOiK5AEnKSDNfNQ9GNUuxJeW5djmyB8nOkVeJU9+idif5f 6TQItlGYouy5blO9mDqVWxPf8T2BcTFmLuCgEO+VLdA0iYkTfZHEY/riMivjtgizuSJFOIZhmAPL q4SFbOa6TZhVlPjdU1dA2irBcqdJ0nkXI1ugIpM0E608E7/76xwpz6/KMwiasG5cXFifqqdZ9Cy+ d0NB0uOtQ9ISX2oLTemPZvdHpcWbWngueklVLvPLpUWwJHkmzHWb8OcvCdvwgmGYA7+/fRqq8hIP nW6LDr+7jX/S+6FPfA9iGaChN7lXKBRJCp/qDZN3ukI40j2GAYlvIRkGOPitGt7yCSHL9rYH9zf2 R9AbjKPSocfiCv7QDB//bB8hp31xdPhicJk1uMZlxEqeCAIAnBuOkXt3dkkpDgBQatfjpnIL5rn0 qJsuPj2Y94S7Xj1HrAYNtCyD+CSHYIyTNGFLxqb6YuqrAWizvdlP/ihxBXginGYt7AbNhbWxOg2D 51aXJm0D3sF5nCPoGBYfJBTKiRQTzanA8e5RqvZ8YxOX3OQ1KbxW3meQUG9KKsd75L9aVpqmQbpJ jpfjtvK3Ma9AhRRmwnz0hcbR6Y9N2VVE/2wfIUpvA5CqE/AKVJan/FKOAx30MlBp8/Z55YfgUjt/ JIZXoMo88WEcsRzoSP5aId28I3KPISmUWvhnOrxHawuN9HJ4kzAQnkAjTxQ5XbzRGlB8eNOyDK4u 4V/8xSuQw6jLc0mMtYlh54fi94hTmh3Nit+bqHKkHqFSRhKudcuPJ6XiUOcoYhN0Nn6gQVP/GGn3 S4u/iWFusTnlb1IKVFeovKPAEeDFhmEqGz/QYOtpdTZUvH5a6oyhlAKtmOlgGBXm+q9NkQ0wOv0x 8o4K3luOnhUUshIULK0rSt0V5RKOc3j2+EDanYW/nvLRSGdLycISYW0qSKBlKi2nf601BELIfaoU loBWb5Qc6aIb2knGrTV2Qb8TJNCKajtDI4UoFdEJDr851P+84gUl4Zl36QVF+Sgwa/GFEmGLvAS3 +q0C30zK5c2OEFoGI6oPdfvbg6SJ8rabybhjlrDeA4gQaFVljip7OBMATx0bVKGkS3lWpd6j1zD4 6jV5lUJ/L6rNHz3YSw518o/RBg2DOS4TKvL02N4sfQJq1rGY4zLi6kITal0mzCums6QQ+DiN6l+e sY1nBqNoGojgw6Go5L1R9RoGa+bkomUwiubBaMpVhmtm5+L7C1yCr0XURbd6o+T+17oTHqtxGrB6 Zi5Wzvj31vk/O+AhNONZDpMGpTYdSqw6FFh0yDNrYdV8vC5Up9fCrGcxEZ9AOM6B0WkwGuPgG43D OzYBf5zAExzHR/4YRgUmRgphzUzbJYsAtjV5ye7WELqDV2YCaVkGL6wuQYmIfR5E35WPv91H3rpo DwS3RYf7vpCPm6+6MqbU5ouS+3d1q+K2pgOjlsWer1clbMPdZ0fIllO+SxLu19U68N3rxa2FEu2a 3TvfCd0nyypuLsvBK+sqmETiAEC108gsVXHHK7VZOyu547RqRi6z7a6Kbdd/Mt+x6lk8cF2+qDw9 QGLSyJZTXuIwavDl2Y6U509y3NaVL3XcGZv4bPUjV44Wr951laD2+9spL3GatFg9K5du0ggtXjw5 RF5oVD46rCa/WOLGLVcp/3ENVZZAfmN+ATM9xZvDTGJ+sVkVcQAV16iuvy4vvd9jo4RRy+LBhept 96maQHWlNmb1TOEz6KnKvXVOVb8Qpuoq7/ULC5lpKdKMpjLzisxYW5vaMaKJ6svwf3FzEbRs5g12 NoMGv1levE3tctPSUnvbAuSlxmH0JJhtT0WqnQbcc20uFpSr+4FBIM3fUf3IHyOHO0dxwhPGB0NR kCkyVdJpGNS6TFgw3Yz6KuuF3YTTwZQaaw51hsj7njBavDF0+ONUtjcTgkHLYGa+EbNdRtQ69VhY oX5PScaUqUgiWgYjpHMkjo/8MbznGYPU7+Fdzox8I+qKTajINaDCoUeVwA0x0sGUrdjl7DzjI0+9 m/w7p2J4Ylkxbiyd2stePiWtmymJwWmlF4nIpG8dZYxAVJmktwhNaTJGoMg4PYchSjLmsjNHoD4R O5CkgsbuvmqRMQJ1h+g1Ki1vUA0yRqAzIr+zzcf7lL8poSQZIVCrN0oGKQ5Lbb4YOI7bRM2ggmSE QPsor8IjAF5p9EnaIEltMkIg2t8gAoDGQeW2F6BJRsymgY8/P3CiJ/z82cEIeoLjGBibxMDoOEai k1ckHZq0LApytHBZtHAaWeSbtHDb9SjI0SFPB1S5zJUMw5xL06V8fvFHx9VZeZUlS5YsWbJkyZIl S5ZM5v8Bx18CQnTzRLgAAAAASUVORK5CYII= "
+       id="image3166"
+       x="16"
+       y="16" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="BADGE"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <g
+       style="display:inline"
+       transform="translate(-340.00001,-581)"
+       id="g4394"
+       clip-path="none">
+      <g
+         id="g855">
+        <g
+           inkscape:groupmode="maskhelper"
+           id="g870"
+           clip-path="url(#clipPath873)"
+           style="opacity:0.6;filter:url(#filter891)">
+          <path
+             transform="matrix(1.4999992,0,0,1.4999992,-29.999795,-237.54282)"
+             d="m 264,552.36218 c 0,6.62742 -5.37258,12 -12,12 -6.62742,0 -12,-5.37258 -12,-12 0,-6.62741 5.37258,-12 12,-12 6.62742,0 12,5.37259 12,12 z"
+             sodipodi:ry="12"
+             sodipodi:rx="12"
+             sodipodi:cy="552.36218"
+             sodipodi:cx="252"
+             id="path844"
+             style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             sodipodi:type="arc" />
+        </g>
+        <g
+           id="g862">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path4398"
+             sodipodi:cx="252"
+             sodipodi:cy="552.36218"
+             sodipodi:rx="12"
+             sodipodi:ry="12"
+             d="m 264,552.36218 c 0,6.62742 -5.37258,12 -12,12 -6.62742,0 -12,-5.37258 -12,-12 0,-6.62741 5.37258,-12 12,-12 6.62742,0 12,5.37259 12,12 z"
+             transform="matrix(1.4999992,0,0,1.4999992,-29.999795,-238.54282)" />
+          <path
+             transform="matrix(1.25,0,0,1.25,33,-100.45273)"
+             d="m 264,552.36218 c 0,6.62742 -5.37258,12 -12,12 -6.62742,0 -12,-5.37258 -12,-12 0,-6.62741 5.37258,-12 12,-12 6.62742,0 12,5.37259 12,12 z"
+             sodipodi:ry="12"
+             sodipodi:rx="12"
+             sodipodi:cy="552.36218"
+             sodipodi:cx="252"
+             id="path4400"
+             style="color:#000000;fill:#dd4814;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             sodipodi:type="arc" />
+          <path
+             sodipodi:type="star"
+             style="color:#000000;fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path4459"
+             sodipodi:sides="5"
+             sodipodi:cx="666.19574"
+             sodipodi:cy="589.50385"
+             sodipodi:r1="7.2431178"
+             sodipodi:r2="4.3458705"
+             sodipodi:arg1="1.0471976"
+             sodipodi:arg2="1.6755161"
+             inkscape:flatsided="false"
+             inkscape:rounded="0.1"
+             inkscape:randomized="0"
+             d="m 669.8173,595.77657 c -0.39132,0.22593 -3.62645,-1.90343 -4.07583,-1.95066 -0.44938,-0.0472 -4.05653,1.36297 -4.39232,1.06062 -0.3358,-0.30235 0.68963,-4.03715 0.59569,-4.47913 -0.0939,-0.44198 -2.5498,-3.43681 -2.36602,-3.8496 0.18379,-0.41279 4.05267,-0.59166 4.44398,-0.81759 0.39132,-0.22593 2.48067,-3.48704 2.93005,-3.4398 0.44938,0.0472 1.81505,3.67147 2.15084,3.97382 0.3358,0.30236 4.08294,1.2817 4.17689,1.72369 0.0939,0.44198 -2.9309,2.86076 -3.11469,3.27355 -0.18379,0.41279 0.0427,4.27917 -0.34859,4.5051 z"
+             transform="matrix(1.511423,-0.16366377,0.16366377,1.511423,-755.37346,-191.93651)" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,2 @@
-includes: ['layer:basic', 'interface:etcd']
+includes: ['layer:basic', 'interface:etcd', 'interface:etcd-cluster']
+exclude: ['Makefile']

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,4 +16,4 @@ provides:
     interface: etcd
 peers:
   cluster:
-    interface: etcd
+    interface: etcd-cluster

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -16,7 +16,7 @@ from charmhelpers.core import host
 from charmhelpers.core import templating
 
 from etcd import EtcdHelper
-from subprocess import CalledProcessError
+
 
 @hook('config-changed')
 def remove_states():
@@ -56,8 +56,6 @@ def cluster_update(cluster):
         remove_state('cluster.joining')
 
 
-
-
 @when('cluster.departed')
 def remove_unit_from_cluster(cluster):
     etcd = EtcdHelper()
@@ -66,6 +64,16 @@ def remove_unit_from_cluster(cluster):
     remove_state('etcd.configured')
     # end of peer-departing event
     remove_state('cluster.departed')
+
+
+@when('db.connected')
+def send_connection_details(client):
+    etcd = EtcdHelper()
+    data = etcd.cluster_data()
+    hosts = []
+    for unit in data:
+        hosts.append(data[unit]['private_address'])
+    client.provide_connection_string(hosts, config('port'))
 
 
 @hook('leader-settings-changed')

--- a/tests/00-setup
+++ b/tests/00-setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo add-apt-repository ppa:juju/stable -y
+sudo apt-get update
+sudo apt-get install amulet -y

--- a/tests/10-deploy
+++ b/tests/10-deploy
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import amulet
+import unittest
+
+
+class TestDeployment(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.deployment = amulet.Deployment(series='trusty')
+        cls.deployment.add('etcd')
+        try:
+            cls.deployment.setup(timeout=900)
+            cls.deployment.sentry.wait()
+        except amulet.helpers.TimeoutError:
+            msg = "Environment wasn't stood up in time"
+            amulet.raise_status(amulet.SKIP, msg=msg)
+        except:
+            raise
+
+    def test_single_service(self):
+        status = self.deployment.sentry['etcd'][0].run('service etcd status')
+        self.assertTrue("running" in status[0])
+
+    def test_two_node_scale(self):
+        self.deployment.add_unit('etcd')
+        self.deployment.sentry.wait()
+
+        status1 = self.deployment.sentry['etcd'][0].run('service etcd status')
+        status2 = self.deployment.sentry['etcd'][1].run('service etcd status')
+        self.assertTrue("running" in status1[0])
+        self.assertTrue("running" in status2[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a string builder to aid when handling *-relation-joined/changed to
    hand out a cluster connection string understood by both families of uses.

```
eg: docker expects etcd:// for swarm discovery eg: everything else on the
planet uses http:// or https:// urls
```
-  Adds icon, new interface declaration etcd-cluster
-  Import the legacy items from the original charm
