### PR TITLE
Fix failure due to recent path.py upgrade

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,2 +1,3 @@
 includes: ['layer:basic', 'interface:etcd']
 exclude: ['Makefile']
+repo: https://github.com/juju-solutions/layer-etcd.git

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,2 @@
 path.py>=8.0.0,<=9.0.0
+setuptools_scm


### PR DESCRIPTION
Path.py as it continues progressing forward into intrepid territory, has moved on to a newer setuptools. I dont have a good idea of if we should pin this, so I'm going to run with the assumption of go with stable until the build breaks, then pin it.
