### PR TITLE
WIP - TLS Branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 resources
+.tox
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 resources
 .tox
 .coverage
+.cache
+__pycache__

--- a/README.md
+++ b/README.md
@@ -87,6 +87,58 @@ juju action fetch <uuid>
 
 ```
 
+The health is also reported continuously via `juju status`. During initial
+cluster turn-up, its entirely reasonable for the health checks to fail. this
+is not a situation to cause you alarm. The health-checks are being executed
+before the cluster has stabilized, and it should even out once the members
+start to come online and the update-status hook is run again.
+
+This will give you some insight into the cluster on a 5 minute interval, and
+will report healthy nodes vs unhealthy nodes.
+
+For example:
+
+```shell
+ID      WORKLOAD-STATUS JUJU-STATUS VERSION   MACHINE PORTS             PUBLIC-ADDRESS MESSAGE
+etcd/9  active          idle        2.0-beta6 10      2379/tcp,2380/tcp 192.168.239.20 cluster-health check failed... needs attention
+etcd/10 active          idle        2.0-beta6 9       2379/tcp,2380/tcp 192.168.91.60  (leader) cluster is healthy
+```
+
+# TLS
+
+The ETCD charm supports TLS terminated endpoints by default. All efforts have
+been made to ensure the PKI is as robust as possible.
+
+Client certificates can be obtained by running an action on any of the cluster
+members:
+
+```shell
+juju run-action etcd/12 generate-client-certificates
+juju scp etcd/12:etcd_client_credentials.tar.gz etcd_credentials.tar.gz
+```
+
+This will place the client certificates in `pwd`. If you're keen on using
+etcdctl outside of the cluster machines,  you'll need to expose the service,
+and export some environment variables to consume the client credentials.
+
+```shell
+juju expose etcd
+export ETCDCTL_KEY_FILE=$(pwd)/clientkey.pem
+export ETCDCTL_CERT_FILE=$(pwd)/clientcert.pem
+export ETCDCTL_CA_FILE=$(pwd)/ca.pem
+export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
+etcdctl member list
+```
+
+### Notes about cluster turn-up
+
+The Etcd charm initializes a cluster using the Static configuration: which
+is the most "flexible" of all the installation options, considering it allows
+Etcd to be self-discovering using the peering relationships provided by
+Juju. Trying to start up etcd behind the corporate firewall? Thanks to
+resources, the charm is now completely stand alone, and supports this.
+
+
 
 # Known Limitations
 
@@ -99,6 +151,10 @@ problem has been resolved](https://github.com/juju-solutions/layer-etcd/issues/5
 
 This charm requires resources to be provided to the charm in order to deploy
 on trusty hosts. This requires juju 2.0 or greater.
+
+If you destroy the leader - identified with the `(leader)` text prepended to
+any status messages: all TLS pki will be lost. No PKI migration occurs outside
+of the units requesting and registering the certificates. You have been warned.
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Its recommended to run an odd number of machines as it has greater redundancy
 than even number (ie. with 4, you can lose 1 before quorum is lost, where as
 with 5, you can lose 2).
 
+### Notes about cluster turn-up
+
+The Etcd charm initializes a cluster using the Static configuration: which
+is the most "flexible" of all the installation options, considering it allows
+Etcd to be self-discovering using the peering relationships provided by
+Juju. Trying to start up etcd behind the corporate firewall? Thanks to
+resources, the charm is now completely stand alone, and supports this.
+
 # The charm told me to see the README
 
 You've been directed here because you're deploying this etcd charm onto a
@@ -129,15 +137,6 @@ export ETCDCTL_CA_FILE=$(pwd)/ca.pem
 export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
 etcdctl member list
 ```
-
-### Notes about cluster turn-up
-
-The Etcd charm initializes a cluster using the Static configuration: which
-is the most "flexible" of all the installation options, considering it allows
-Etcd to be self-discovering using the peering relationships provided by
-Juju. Trying to start up etcd behind the corporate firewall? Thanks to
-resources, the charm is now completely stand alone, and supports this.
-
 
 
 # Known Limitations

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,3 +1,6 @@
 health:
     description: Call the health of the cluster
-
+package-client-credentials:
+    description: |
+     Generate a tarball of the client certificates to connect to the cluster
+     remotely.

--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# The certificates live in leader-data. Grab them from there, always
+
+mkdir -p etcd_credentials
+
+leader-get client_certificate > etcd_credentials/clientcert.pem
+leader-get client_key > etcd_credentials/clientkey.pem
+leader-get certificate_authority > etcd_credentials/ca.pem
+
+# Render a README heredoc
+cat << EOF > etcd_credentials/README.txt
+# ETCD Credentials Package
+
+Greetings! This credentials package was generated for you by Juju. In order
+to consume these keys, you will need to do a few things first:
+
+Untarball the archive somewhere you wish to keep your sensitive client
+credentials.
+
+Export those locations as environment variables, set the etcdctl endpoint,
+and expose the etcd service. Even though Etcd is currently configured to
+validate SSL certificates before a connection can be established, its best
+practice to leave it firewalled from the world unless you have need of an
+exposed etcd endpoint.
+
+  juju expose etcd
+  export ETCDCTL_KEY_FILE=$(pwd)/clientkey.pem
+  export ETCDCTL_CERT_FILE=$(pwd)/clientcert.pem
+  export ETCDCTL_CA_FILE=$(pwd)/ca.pem
+  export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
+  etcdctl member list
+
+If you have any trouble regarding connecting to your Etcd cluster, don't
+hesitate to reach out over the juju mailing list: juju@lists.ubuntu.com
+
+EOF
+
+tar cfz etcd_credentials.tar.gz etcd_credentials
+cp etcd_credentials.tar.gz /home/ubuntu/

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 options:
   port:
     type: int
-    default: 4001
+    default: 2379
     description: Port to run the public ETCD service on
   management_port:
     type: int
-    default: 7001
+    default: 2380
     description: Port to run the ETCD Management service

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,3 @@
-includes: ['layer:basic', 'interface:etcd']
+includes: ['layer:basic', 'layer:tls', 'interface:etcd']
 exclude: ['Makefile']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,7 @@
-includes: ['layer:basic', 'layer:tls', 'interface:etcd', 'interface:etcd-proxy']
-exclude: ['Makefile']
+includes:
+  - 'layer:basic'
+  - 'layer:tls'
+  - 'interface:etcd'
+  - 'interface:etcd-proxy'
+exclude: ['Makefile', 'tests/10-tls-deploy.py']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,3 @@
-includes: ['layer:basic', 'interface:etcd']
+includes: ['layer:basic', 'interface:etcd', 'interface:etcd-proxy']
 exclude: ['Makefile']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,3 @@
-includes: ['layer:basic', 'interface:etcd', 'interface:etcd-proxy']
+includes: ['layer:basic', 'layer:tls', 'interface:etcd', 'interface:etcd-proxy']
 exclude: ['Makefile']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,6 @@
-includes: ['layer:basic', 'layer:tls', 'interface:etcd']
-exclude: ['Makefile']
+includes: 
+  - 'layer:basic'
+  - 'layer:tls'
+  - 'interface:etcd'
+exclude: ['Makefile', 'tests/10-tls-deploy.py']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -1,0 +1,87 @@
+from charmhelpers.core.hookenv import log
+from subprocess import CalledProcessError
+from shlex import split
+from subprocess import check_output
+import os
+
+
+class EtcdCtl:
+    ''' etcdctl modeled as a python class. This python wrapper consumes
+    and exposes some of the commands contained in etcdctl. Related to unit
+    registration, cluster health, and other operations '''
+
+    def register(self, cluster_data):
+        ''' Perform self registration against the etcd leader.
+
+        @params cluster_data - a dict of data to fill out the request to
+        push our registration to the leader
+        requires keys: leader_address, port, unit_name, private_address,
+        management_port
+        '''
+        command = "etcdctl -C http://{}:{} member add {}" \
+                  " http://{}:{}".format(cluster_data['leader_address'],
+                                         cluster_data['port'],
+                                         cluster_data['unit_name'],
+                                         cluster_data['private_address'],
+                                         cluster_data['management_port'])
+
+        try:
+            self.run(command)
+        except CalledProcessError:
+            log('Notice:  Unit failed self registration', 'WARNING')
+
+    def unregister(self, cluster_data):
+        ''' Perform self deregistration during unit teardown
+
+        @params cluster_data - a dict of data to fill out the request to push
+        our deregister command to the leader. requires  keys: leader_address,
+        port, etcd_unit_guid
+
+        The unit_id can be obtained from the etcdctl.member_list() dict
+        '''
+        command = "etcdctl -C http://{}:{} member remove " \
+                  "{}".format(cluster_data['leader_address'],
+                              cluster_data['port'],
+                              cluster_data['unit_id'])
+        self.run(command)
+
+    def member_list(self):
+        ''' Returns the output from `etcdctl member list` as a python dict
+        organized by unit_name, containing all the data-points in the resulting
+        response. '''
+
+        members = {}
+        out = self.run("etcdctl member list")
+        raw_member_list = out.strip('\n').split('\n')
+        print(raw_member_list)
+        # Expect output like this:
+        # 4f24ee16c889f6c1: name=etcd20 peerURLs=https://10.113.96.197:2380 clientURLs=https://10.113.96.197:2379  # noqa
+        # edc04bb81479d7e8: name=etcd21 peerURLs=https://10.113.96.243:2380 clientURLs=https://10.113.96.243:2379  # noqa
+
+        for unit in raw_member_list:
+            unit_guid = unit.split(':')[0]
+            unit_name = unit.split(' ')[1].split("=")[-1]
+            peer_urls = unit.split(' ')[2].split("=")[-1]
+            client_urls = unit.split(' ')[3].split("=")[-1]
+
+            members[unit_name] = {'unit_id': unit_guid,
+                                  'name': unit_name,
+                                  'peer_urls': peer_urls,
+                                  'client_urls': client_urls}
+        return members
+
+    def cluster_health(self):
+        ''' Returns the output of etcdctl cluster-health as a python dict
+        organized by topical information with detailed unit output '''
+
+        out = self.run('etcdctl cluster-health')
+        health_output = out.strip('\n').split('\n')
+        return {'status': health_output[-1], 'units': health_output[0:-2]}
+
+    def run(self, command):
+        ''' Wrapper to subprocess calling output. This is a convenience
+        method to clean up the calls to subprocess and append TLS data'''
+        os.environ['ETCDCTL_CA_FILE'] = '/etc/ssl/etcd/ca.pem'
+        os.environ['ETCDCTL_CERT_FILE'] = '/etc/ssl/etcd/server.pem'
+        os.environ['ETCDCTL_KEY_FILE'] = '/etc/ssl/etcd/server-key.pem'
+        return check_output(split(command)).decode('ascii')

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,11 @@
 name: etcd
-summary: ETCD charm layer
+summary: Deploy a TLS terminated ETCD Cluster
 maintainers:
     - Charles Butler <charles.butler@canonical.com>
 description: |
-  A minimalist layer to deliver ETCD as a service
+  This charm supports deploying Etcd from the upstream binaries with resources.
+  It will also TLS wrap your service, and distribute client keys to any service
+  connecting. Etcd is a highly available key/value store.
 tags:
   - database
   - keystore

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,8 +11,8 @@ tags:
   - keystore
   - layer
 series:
-  - trusty
   - xenial
+  - trusty
 min-juju-version: 2.0-beta6
 resources:
   etcd:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,6 +25,8 @@ subordinate: false
 provides:
   db:
     interface: etcd
+  proxy:
+    interface: etcd-proxy
 peers:
   cluster:
     interface: etcd

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -18,14 +18,16 @@ from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import log
 from charmhelpers.core import host
 from charmhelpers.core import templating
+from charmhelpers.core import unitdata
 from charmhelpers.fetch import apt_update
 from charmhelpers.fetch import apt_install
 
 from etcd import EtcdHelper
 from pwd import getpwnam
+from shlex import split
+from shutil import copyfile
 from subprocess import check_call
 from subprocess import CalledProcessError
-from shlex import split
 
 import os
 
@@ -157,6 +159,10 @@ def install_etcd():
         os.chmod('/var/lib/etcd/', 0o775)
         os.chown('/var/lib/etcd/', etcd_uid, -1)
 
+        if codename == 'trusty':
+            set_state('etcd.installed')
+            return
+
         if not os.path.exists('/etc/systemd/system/etcd.service'):
             templating.render('systemd', '/etc/systemd/system/etcd.service',
                               {}, owner='root', group='root')
@@ -172,14 +178,29 @@ def install_etcd():
 
 
 @when('etcd.installed')
-@when('tls.server.certificate available')
+@when('etcd.ssl.placed')
 @when_not('etcd.configured')
 def configure_etcd():
+    ''' There's a lot going on in here. Minimally stating, we are gaging the
+    state of the world and broadcasting that if we are the leader. Otherwise we
+    are looking to leader data, and what we can get from config to generate our
+    services config during the registration sequence '''
+    # This library has some convience methods to generate cluster strings from
+    # relation data, and other 'helpers'. Use it to generate as much shared
+    # config as possible before we diverge for leader/follower
     etcd_helper = EtcdHelper()
     cluster_data = {'private_address': unit_get('private-address')}
     cluster_data['unit_name'] = etcd_helper.unit_name
     cluster_data['management_port'] = config('management_port')
     cluster_data['port'] = config('port')
+
+    # TLS - this is a relatively new concern, and i'd like to keep a
+    # close eye on it until this branch settles.
+    ssl_path = '/etc/ssl/etcd'
+    cluster_data['ca_certificate'] = '{}/ca.pem'.format(ssl_path)
+    cluster_data['server_certificate'] = '{}/server.pem'.format(ssl_path)
+    cluster_data['server_key'] = '{}/server-key.pem'.format(ssl_path)
+
     # The leader broadcasts the cluster settings, as the leader controls the
     # state of the cluster. This assumes the leader is always initializing new
     # clusters, and may need to be adapted later to support existing cluster
@@ -202,7 +223,8 @@ def configure_etcd():
         cluster_data['leader_address'] = leader_get('leader_address')
         # self registration provided via the helper class
         etcd_helper.register(cluster_data)
-
+    # Now that we have configured for the upset, lets render our environment
+    # details/files and prepare to do some work
     codename = host.lsb_release()['DISTRIB_CODENAME']
     if codename == 'trusty':
         templating.render('upstart', '/etc/init/etcd.conf',
@@ -213,6 +235,34 @@ def configure_etcd():
 
     host.service('restart', 'etcd')
     set_state('etcd.configured')
+
+
+@when('tls.server.certificate available')
+@when_not('etcd.ssl.placed')
+def install_etcd_certificates():
+    etcd_ssl_path = '/etc/ssl/etcd'
+    if not os.path.exists(etcd_ssl_path):
+        os.makedirs(etcd_ssl_path)
+
+    kv = unitdata.kv()
+    cert = kv.get('tls.server.certificate')
+    with open('{}/server.pem'.format(etcd_ssl_path), 'w+') as f:
+        f.write(cert)
+    with open('{}/ca.pem'.format(etcd_ssl_path), 'w+') as f:
+        f.write(leader_get('certificate_authority'))
+
+    # schenanigans - each server makes its own key, when generating
+    # the CSR. This is why its "magically" present.
+    keypath = 'easy-rsa/easyrsa3/pki/private/{}.key'
+    server = os.getenv('JUJU_UNIT_NAME').replace('/', '_')
+    if os.path.exists(keypath.format(server)):
+        copyfile(keypath.format(server),
+                 '{}/server-key.pem'.format(etcd_ssl_path))
+    else:
+        copyfile(keypath.format(unit_get('public-address')),
+                 '{}/server-key.pem'.format(etcd_ssl_path))
+
+    set_state('etcd.ssl.placed')
 
 
 @when('etcd.configured')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -96,6 +96,12 @@ def send_connection_details(client):
     client.provide_connection_string(hosts, config('port'))
 
 
+@when('proxy.connected')
+def send_cluster_details(proxy):
+    etcd = EtcdHelper()
+    proxy.provide_cluster_string(etcd.cluster_string())
+
+
 @hook('leader-settings-changed')
 def update_cluster_string():
     # When the leader makes a broadcast, assume an upset and prepare for

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from charms.reactive import when
+from charms.reactive import when_any
 from charms.reactive import when_not
 from charms.reactive import set_state
 from charms.reactive import remove_state
@@ -14,6 +15,7 @@ from charmhelpers.core.hookenv import resource_get
 
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import unit_get
+from charmhelpers.core.hookenv import log
 from charmhelpers.core import host
 from charmhelpers.core import templating
 from charmhelpers.fetch import apt_update
@@ -44,6 +46,11 @@ def remove_configuration_state():
     cluster_data['cluster'] = etcd_helper.cluster_string()
     cluster_data['leader_address'] = unit_get('private-address')
     leader_set(cluster_data)
+
+
+@when_any('config.port.changed', 'config.management_port.changed')
+def update_port_mappings():
+    remove_state('etcd.configured')
 
 
 @when('cluster.declare_self')
@@ -159,6 +166,7 @@ def install_etcd():
 
 
 @when('etcd.installed')
+@when('tls.server.certificate available')
 @when_not('etcd.configured')
 def configure_etcd():
     etcd_helper = EtcdHelper()
@@ -209,6 +217,33 @@ def service_messaging():
         status_set('active', 'Etcd leader running')
     else:
         status_set('active', 'Etcd follower running')
+
+
+@when('easyrsa installed')
+@when_not('etcd.tls.opensslconfig.modified')
+def inject_swarm_tls_template():
+    """
+    layer-tls installs a default OpenSSL Configuration that is incompatibile
+    with how etcd expects TLS keys to be generated. We will append what
+    we need to the x509-type, and poke layer-tls to regenerate.
+    """
+    if is_leader():
+        status_set('maintenance', 'Reconfiguring SSL PKI configuration')
+
+        log('Updating EasyRSA3 OpenSSL Config')
+        openssl_config = 'easy-rsa/easyrsa3/x509-types/server'
+
+        with open(openssl_config, 'r') as f:
+            existing_template = f.readlines()
+
+        # use list comprehension to enable clients,server usage for
+        # certificate with the docker/swarm daemons.
+        xtype = [w.replace('serverAuth', 'serverAuth, clientAuth') for w in existing_template]  # noqa
+        with open(openssl_config, 'w+') as f:
+            f.writelines(xtype)
+
+        set_state('etcd.tls.opensslconfig.modified')
+        set_state('easyrsa configured')
 
 
 def install(src, tgt):

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -144,6 +144,14 @@ def install_etcd():
             pkg_list = ['etcd']
             apt_update()
             apt_install(pkg_list, fatal=True)
+            # Stop the service and remove the defaults
+            # I hate that I have to do this. Sorry short-lived local data #RIP
+            # State control is to prevent upgrade-charm from nuking cluster
+            # data.
+            if not is_state('etcd.package.adjusted'):
+                host.service('stop', 'etcd')
+                rmtree('/var/lib/etcd/')
+                set_state('etcd.package.adjusted')
             set_state('etcd.installed')
             return
         else:

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -7,15 +7,16 @@ from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import hook
 
-from charmhelpers.core.hookenv import status_set
+from charmhelpers.core.hookenv import status_set as hess
 from charmhelpers.core.hookenv import is_leader
 from charmhelpers.core.hookenv import leader_set
 from charmhelpers.core.hookenv import leader_get
 from charmhelpers.core.hookenv import resource_get
 
 from charmhelpers.core.hookenv import config
-from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import log
+from charmhelpers.core.hookenv import open_port
+from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core import host
 from charmhelpers.core import templating
 from charmhelpers.core import unitdata
@@ -50,8 +51,10 @@ def remove_configuration_state():
     leader_set(cluster_data)
 
 
-@when_any('config.port.changed', 'config.management_port.changed')
+@when_any('config.changed.port', 'config.changed.management_port')
 def update_port_mappings():
+    open_port(config('port'))
+    open_port(config('management_port'))
     remove_state('etcd.configured')
 
 
@@ -296,6 +299,24 @@ def inject_swarm_tls_template():
         set_state('easyrsa configured')
 
 
+@when_not('etcd.pillowmints')
+def render_default_user_ssl_exports():
+    with open('/home/ubuntu/.bash_aliases', 'w+') as fp:
+        fp.writelines(['export ETCDCTL_KEY_FILE=/etc/ssl/etcd/server-key.pem\n',  # noqa
+                       'export ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.pem\n',
+                       'export ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.pem\n'])
+
+    set_state('etcd.pillowmints')
+
+
 def install(src, tgt):
     ''' This method wraps the bash 'install' command '''
     return check_call(split('install {} {}'.format(src, tgt)))
+
+
+def status_set(status, message):
+    ''' This is a fun little hack to give me the leader in status output
+        without taking it over '''
+    if is_leader():
+        message = "* {}".format(message)
+    hess(status, message)

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -33,7 +33,7 @@ from subprocess import CalledProcessError
 import os
 
 
-@hook('update-status')
+@when('etcd.configured')
 def check_cluster_health():
     # We have an opportunity to report on the cluster health every 5
     # minutes, lets leverage that.
@@ -171,7 +171,10 @@ def install_etcd():
         os.chmod('/var/lib/etcd/', 0o775)
         os.chown('/var/lib/etcd/', etcd_uid, -1)
 
+        # Trusty was the EOL for upstart, render its template if required
         if codename == 'trusty':
+            templating.render('upstart', '/etc/init/etcd.conf',
+                              {}, owner='root', group='root')
             set_state('etcd.installed')
             return
 
@@ -237,13 +240,9 @@ def configure_etcd():
         etcd_helper.register(cluster_data)
     # Now that we have configured for the upset, lets render our environment
     # details/files and prepare to do some work
-    codename = host.lsb_release()['DISTRIB_CODENAME']
-    if codename == 'trusty':
-        templating.render('upstart', '/etc/init/etcd.conf',
-                          cluster_data, owner='root', group='root')
-    else:
-        templating.render('defaults', '/etc/default/etcd',
-                          cluster_data, owner='root', group='root')
+
+    templating.render('defaults', '/etc/default/etcd',
+                      cluster_data, owner='root', group='root')
 
     host.service('restart', 'etcd')
     set_state('etcd.configured')
@@ -323,5 +322,5 @@ def status_set(status, message):
     ''' This is a fun little hack to give me the leader in status output
         without taking it over '''
     if is_leader():
-        message = "* {}".format(message)
+        message = "(leader) {}".format(message)
     hess(status, message)

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -150,6 +150,14 @@ def install_etcd():
             pkg_list = ['etcd']
             apt_update()
             apt_install(pkg_list, fatal=True)
+            # Stop the service and remove the defaults
+            # I hate that I have to do this. Sorry short-lived local data #RIP
+            # State control is to prevent upgrade-charm from nuking cluster
+            # data.
+            if not is_state('etcd.package.adjusted'):
+                host.service('stop', 'etcd')
+                rmtree('/var/lib/etcd/')
+                set_state('etcd.package.adjusted')
             set_state('etcd.installed')
             return
         else:

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -33,6 +33,15 @@ from subprocess import CalledProcessError
 import os
 
 
+@hook('update-status')
+def check_cluster_health():
+    # We have an opportunity to report on the cluster health every 5
+    # minutes, lets leverage that.
+    etcd_helper = EtcdHelper()
+    health = etcd_helper.get_cluster_health_output()
+    status_set('active', health)
+
+
 @hook('upgrade-charm')
 def remove_states():
     # upgrade-charm issues when we rev resources and the charm. Assume an upset
@@ -260,16 +269,6 @@ def install_etcd_certificates():
                  '{}/server-key.pem'.format(etcd_ssl_path))
 
     set_state('etcd.ssl.placed')
-
-
-@when('etcd.configured')
-def service_messaging():
-    ''' I really like seeing the leadership status as my default message for
-        etcd so I know who the MVP is. This method reflects that. '''
-    if is_leader():
-        status_set('active', 'Etcd leader running')
-    else:
-        status_set('active', 'Etcd follower running')
 
 
 @when('easyrsa installed')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -3,6 +3,7 @@
 from charms.reactive import when
 from charms.reactive import when_any
 from charms.reactive import when_not
+from charms.reactive import is_state
 from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import hook
@@ -27,8 +28,10 @@ from etcd import EtcdHelper
 from pwd import getpwnam
 from shlex import split
 from shutil import copyfile
+from shutil import rmtree
 from subprocess import check_call
 from subprocess import CalledProcessError
+from tlslib import client_cert
 
 import os
 
@@ -130,6 +133,32 @@ def update_cluster_string():
     remove_state('etcd.configured')
 
 
+@when('etcd.ssl.placed')
+@when_not('client-credentials-relayed')
+def relay_client_credentials():
+
+    # offer a short circuit if we have already received broadcast
+    # credentials for the cluster
+    if leader_get('client_certificate') and leader_get('client_key'):
+        with open('client.crt', 'w+') as fp:
+            fp.write(leader_get('client_certificate'))
+        with open('client.key', 'w+') as fp:
+            fp.write(leader_get('client_key'))
+        set_state('client-credentials-relayed')
+        return
+
+    if is_leader():
+        charm_dir = os.getenv('CHARM_DIR')
+        client_cert(charm_dir)
+        with open('client.crt') as fp:
+            client_certificate = fp.read()
+        with open('client.key') as fp:
+            client_key = fp.read()
+        leader_set({'client_certificate': client_certificate,
+                    'client_key': client_key})
+        set_state('client-credentials-relayed')
+
+
 @when_not('etcd.installed')
 def install_etcd():
     status_set('maintenance', 'Installing etcd.')
@@ -156,7 +185,7 @@ def install_etcd():
             # data.
             if not is_state('etcd.package.adjusted'):
                 host.service('stop', 'etcd')
-                rmtree('/var/lib/etcd/')
+                rmtree('/var/lib/etcd/default')
                 set_state('etcd.package.adjusted')
             set_state('etcd.installed')
             return
@@ -287,11 +316,11 @@ def install_etcd_certificates():
 @when('easyrsa installed')
 @when_not('etcd.tls.opensslconfig.modified')
 def inject_swarm_tls_template():
-    """
+    '''
     layer-tls installs a default OpenSSL Configuration that is incompatibile
     with how etcd expects TLS keys to be generated. We will append what
     we need to the x509-type, and poke layer-tls to regenerate.
-    """
+    '''
     if is_leader():
         status_set('maintenance', 'Reconfiguring SSL PKI configuration')
 
@@ -313,11 +342,16 @@ def inject_swarm_tls_template():
 
 @when_not('etcd.pillowmints')
 def render_default_user_ssl_exports():
-    with open('/home/ubuntu/.bash_aliases', 'w+') as fp:
-        fp.writelines(['export ETCDCTL_KEY_FILE=/etc/ssl/etcd/server-key.pem\n',  # noqa
-                       'export ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.pem\n',
-                       'export ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.pem\n'])
+    ''' Add secure credentials to default user environment configs,
+    transparently adding TLS '''
+    evars = ['export ETCDCTL_KEY_FILE=/etc/ssl/etcd/server-key.pem\n',  # noqa
+             'export ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.pem\n',
+             'export ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.pem\n']
 
+    with open('/home/ubuntu/.bash_aliases', 'w+') as fp:
+        fp.writelines(evars)
+    with open('/root/.bash_aliases', 'w+') as fp:
+        fp.writelines(evars)
     set_state('etcd.pillowmints')
 
 

--- a/templates/defaults
+++ b/templates/defaults
@@ -1,10 +1,21 @@
+# This file is rendered by Juju, manual edits will not be persisted
 ETCD_DATA_DIR=/var/lib/etcd/default
 ETCD_NAME={{ unit_name }}
-ETCD_ADVERTISE_CLIENT_URLS="http://{{ private_address }}:{{ port }}"
-ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:{{ port }},http://{{ private_address }}:{{ port }}"
-ETCD_LISTEN_PEER_URLS="http://{{ private_address }}:{{ management_port }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="http://{{ private_address }}:{{ management_port }}"
-ETCD_ADVERTISE_PEER_URLS="http://{{ private_address }}:{{ management_port }}"
+ETCD_ADVERTISE_CLIENT_URLS="https://{{ private_address }}:{{ port }}"
+ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:{{ port }},https://{{ private_address }}:{{ port }}"
+ETCD_LISTEN_PEER_URLS="https://{{ private_address }}:{{ management_port }}"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ private_address }}:{{ management_port }}"
+# ETCD_ADVERTISE_PEER_URLS="https://{{ private_address }}:{{ management_port }}"
 ETCD_INITIAL_CLUSTER="{{ cluster }}"
 ETCD_INITIAL_CLUSTER_STATE={{ cluster_state }}
-ETCD_INITIAL_CLUSTER_TOKEN={{ cluster_token }}
+ETCD_INITIAL_CLUSTER_TOKEN={{ token }}
+# SSL CONFIGURATION
+ETCD_CERT_FILE={{ server_certificate }}
+ETCD_KEY_FILE={{ server_key }}
+ETCD_TRUSTED_CA_FILE={{ ca_certificate }}
+ETCD_PEER_CERT_FILE={{ server_certificate }}
+ETCD_PEER_KEY_FILE={{ server_key }}
+ETCD_PEER_TRUSTED_CA_FILE={{ ca_certificate }}
+# SSL Strict Mode
+ETCD_PEER_CLIENT_CERT_AUTH=true
+ETCD_CLIENT_CERT_AUTH=true

--- a/templates/upstart
+++ b/templates/upstart
@@ -12,9 +12,17 @@ setuid etcd
 setgid etcd
 
 exec /usr/bin/etcd \
+    --cert-file={{ server_certificate }} \
+    --key-file={{ server_key }} \
+    --trusted-ca-file={{ ca_certificate }} \
+    --client-cert-auth=true \
+    --peer-cert-file={{ server_certificate }} \
+    --peer-key-file={{ server_key }} \
+    --peer-trusted-ca-file={{ ca_certificate }} \
+    --peer-client-cert-auth=true \
     --initial-advertise-peer-urls http://{{ private_address }}:{{ management_port }} \
     --listen-peer-urls http://{{ private_address }}:{{ management_port }} \
-    --listen-client-urls http://127.0.0.1:{{ port }},http://{{private_address}}:{{ port }} \
+    --listen-client-urls http://127.0.0.1:4001,http://{{private_address}}:{{ port }} \
     --advertise-client-urls http://{{private_address}}:{{ port }} \
     --initial-cluster-token {{ token }} \
     --initial-cluster-state {{ cluster_state }} \

--- a/templates/upstart
+++ b/templates/upstart
@@ -11,21 +11,9 @@ kill timeout 60 # wait 60s between SIGTERM and SIGKILL.
 setuid etcd
 setgid etcd
 
-exec /usr/bin/etcd \
-    --cert-file={{ server_certificate }} \
-    --key-file={{ server_key }} \
-    --trusted-ca-file={{ ca_certificate }} \
-    --client-cert-auth=true \
-    --peer-cert-file={{ server_certificate }} \
-    --peer-key-file={{ server_key }} \
-    --peer-trusted-ca-file={{ ca_certificate }} \
-    --peer-client-cert-auth=true \
-    --initial-advertise-peer-urls http://{{ private_address }}:{{ management_port }} \
-    --listen-peer-urls http://{{ private_address }}:{{ management_port }} \
-    --listen-client-urls http://127.0.0.1:4001,http://{{private_address}}:{{ port }} \
-    --advertise-client-urls http://{{private_address}}:{{ port }} \
-    --initial-cluster-token {{ token }} \
-    --initial-cluster-state {{ cluster_state }} \
-    --initial-cluster={{ cluster }} \
-    --data-dir="/var/lib/etcd/" \
-    --name="{{ unit_name }}"
+
+script
+  set -a
+  . /etc/default/etcd
+  /usr/bin/etcd
+end script

--- a/tests/10-deploy
+++ b/tests/10-deploy
@@ -7,7 +7,7 @@ import unittest
 class TestDeployment(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.deployment = amulet.Deployment(series='trusty')
+        cls.deployment = amulet.Deployment(series='xenial')
         cls.deployment.add('etcd')
         try:
             cls.deployment.setup(timeout=900)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+skipsdist=True
+envlist = py34, py35
+skip_missing_interpreters = True
+
+[testenv]
+commands = py.test -v
+deps =
+    -r{toxinidir}/requirements.txt
+
+[flake8]
+exclude=docs

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,18 @@ envlist = py34, py35
 skip_missing_interpreters = True
 
 [testenv]
-commands = py.test -v
+setenv =
+  PYTHONPATH = {toxinidir}/lib
 deps =
-    -r{toxinidir}/requirements.txt
+    pytest
+    pytest-cov
+    pytest-capturelog
+    mock
+    charmhelpers
+    charms.reactive
+
+commands =
+  py.test -v {posargs} --cov=lib --cov-report=term-missing
 
 [flake8]
 exclude=docs

--- a/unit_tests/test_etcdctcl.py
+++ b/unit_tests/test_etcdctcl.py
@@ -1,0 +1,54 @@
+import pytest
+
+from etcdctl import EtcdCtl
+from mock import patch
+
+
+class TestEtcdCtl:
+
+    @pytest.fixture
+    def etcdctl(self):
+        return EtcdCtl()
+
+    def test_register(self):
+        with patch('etcdctl.check_output') as spcm:
+            self.etcdctl().register({'private_address': '127.0.0.1',
+                                     'port': '1212',
+                                     'unit_name': 'etcd0',
+                                     'management_port': '1313',
+                                     'leader_address': '127.1.1.1'})
+            spcm.assert_called_with(['etcdctl',
+                                     '-C',
+                                     'http://127.1.1.1:1212',
+                                     'member',
+                                     'add',
+                                     'etcd0',
+                                     'http://127.0.0.1:1313'])  # noqa
+
+    def test_unregister(self):
+        with patch('etcdctl.check_output') as spcm:
+            self.etcdctl().unregister({'leader_address': '127.1.1.1',
+                                       'port': '1212',
+                                       'unit_id': 'br1212121212'})
+
+            spcm.assert_called_with(['etcdctl',
+                                     '-C',
+                                     'http://127.1.1.1:1212',
+                                     'member',
+                                     'remove',
+                                     'br1212121212'])
+
+    def test_member_list(self):
+        with patch('etcdctl.check_output') as comock:
+            comock.return_value = b'7dc8404daa2b8ca0: name=etcd22 peerURLs=https://10.113.96.220:2380 clientURLs=https://10.113.96.220:2379\n'  # noqa
+            members = self.etcdctl().member_list()
+            assert(members['etcd22']['unit_id'] == '7dc8404daa2b8ca0')
+            assert(members['etcd22']['peer_urls'] == 'https://10.113.96.220:2380')  # noqa
+            assert(members['etcd22']['client_urls'] == 'https://10.113.96.220:2379')  # noqa
+
+    def test_cluster_health_unhealthy(self):
+        with patch('etcdctl.check_output') as comock:
+            comock.return_value = b''
+
+    def test_cluster_health_healthy(self):
+        pass


### PR DESCRIPTION
This branch completes server side, peer to peer, and client communication TLS termination.
- Adds cluster health messaging
- Overrides status_set with "(leader) " for condensed identification
- TLS certificates are now generated with ClientAuth/ServerAuth so server keys may be used to communicate with the cluster
- Updates DEFAULTS template with TLS components

TODO Items remaining: 
- [ ] Will upgrade a running cluster, but will not properly upgrade the cluster string, resulting in an unhealthy cluster
- [x] Does not properly work yet on Trusty
- [ ] Does not hand off client certificates over interface: etcd
- [x] Tests are now horribly broken, and need refactored to expect/work-with the TLS certificates.
