### PR TITLE
Re-add the etcd-proxy relation

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,3 @@
-includes: ['layer:basic', 'interface:etcd']
+includes: ['layer:basic', 'interface:etcd', 'interface:etcd-proxy']
 exclude: ['Makefile']
 repo: https://github.com/juju-solutions/layer-etcd.git

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,6 +25,8 @@ subordinate: false
 provides:
   db:
     interface: etcd
+  proxy:
+    interface: etcd-proxy
 peers:
   cluster:
     interface: etcd

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -96,6 +96,12 @@ def send_connection_details(client):
     client.provide_connection_string(hosts, config('port'))
 
 
+@when('proxy.connected')
+def send_cluster_details(proxy):
+    etcd = EtcdHelper()
+    proxy.provide_cluster_string(etcd.cluster_string())
+
+
 @hook('leader-settings-changed')
 def update_cluster_string():
     # When the leader makes a broadcast, assume an upset and prepare for


### PR DESCRIPTION
This PR re-introduces the etcd-proxy interface and relationship intended for Etcd to distribute its cluster-string (administrative initial-cluster) to remote proxy units, that will bind to localhost and forward traffic to the etcd cluster.

Read more about this feature here: https://coreos.com/etcd/docs/latest/proxy.html
