### PR TITLE
Moves xenial to the top of the list

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,8 +9,8 @@ tags:
   - keystore
   - layer
 series:
-  - trusty
   - xenial
+  - trusty
 min-juju-version: 2.0-beta6
 resources:
   etcd:


### PR DESCRIPTION
Juju seems to favor the first listed series in metadata unless you
explicitly override it on the cli/bundle. This change defaults to using
xenial which has a clean install path if no resources are available.
