### PR TITLE
Add missing state causing race with cluster state

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -154,6 +154,7 @@ def send_single_connection_details(db):
 
 
 @when('proxy.connected')
+@when('etcd.ssl.placed')
 def send_cluster_details(proxy):
     cert = leader_get('client_certificate')
     key = leader_get('client_key')


### PR DESCRIPTION
Juju doesn't guarantee order of relations. We have to be aware and gate on the proper states indicating the cluster is stable and can perform self assessment.

Fixes #33 
