### PR TITLE
Guard with additional states

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -155,7 +155,10 @@ def send_single_connection_details(db):
 
 @when('proxy.connected')
 @when('etcd.ssl.placed')
+@when_any('etcd.leader.configured', 'cluster.joined')
 def send_cluster_details(proxy):
+    ''' Attempts to send the peer cluster string to
+    proxy units so they can join and act on behalf of the cluster. '''
     cert = leader_get('client_certificate')
     key = leader_get('client_key')
     ca = leader_get('certificate_authority')


### PR DESCRIPTION
The problem surfaced that the last commit fixed was incomplete. This adds additional state guards to the proxy relation to ensure we're not attempting introspection too early on the cluster from the units context.

still related to #33 
