### PR TITLE
Remove trusty support from the layer

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,6 @@ tags:
   - layer
 series:
   - xenial
-  - trusty
 min-juju-version: 2.0-beta6
 resources:
   etcd:


### PR DESCRIPTION
Trusty doesn't have an archive option for installing etcd. The big
line items this resolves is crossing the barrier from tls by default.

Trusty series published versions of this charm have all been targeting
development channels. I feel this is a good time to break that backwords
compat and move forward with tls by default in xenial.
