### PR TITLE
Various cleanups related to pre-promulgation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ resources
 .tox
 .DS_Store
 __pycache__
+.coverage
+.unit-state.db
+*.swp
+.cache/*

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ If you destroy the leader - identified with the `(leader)` text prepended to
 any status messages: all TLS pki will be lost. No PKI migration occurs outside
 of the units requesting and registering the certificates. You have been warned.
 
+Additionally, this charm breaks with no backwords compat/upgrade path at the trusty/xenial
+series boundary. Xenial forward will enable TLS by default. This is an incompatible break
+due to the nature of peer relationships, and how the certificates are generated/passed off.
+
+To migrate from trusty to xenial, the operator will be responsible for deploying the
+xenial etcd cluster, then issuing an etcd data dump on the trusty series, and importing
+that data into the new cluster. This can be performed on a single node due to the
+nature of how replicas work in Etcd.
+
+Any issues with the above process should be filed against the charm layer in github. 
 
 ## Contributors
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,6 @@ tags:
   - layer
 series:
   - xenial
-  - trusty
 min-juju-version: 2.0-beta6
 resources:
   etcd:

--- a/tests/10-tls-deploy.py
+++ b/tests/10-tls-deploy.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python
+
+print("This does nothing, hurray for a free green")

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,0 +1,3 @@
+tests: "10-*"
+packages:
+  - amulet


### PR DESCRIPTION
This branch will need as a pre-requisite:
- Latest test tooling from tvansteenburgh
- Latest charm-tool installed from MASTER due to proof errors
  
  This branch changes:
- Better ignoring of in-place test files
- Updates README with proper migration instructions for users who do
  that sort of thing
  - Removes trusty from metadata
  - Overrides 10-tls-deploy test
  - Adds tests.yaml to install amulet instead of relying on 00-setup
