### PR TITLE
Tweaks for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+ - '3.5'
+
+install:
+ - pip install tox
+
+script:
+ - tox

--- a/tests/00-setup
+++ b/tests/00-setup
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sudo add-apt-repository ppa:juju/stable -y
-sudo apt-get update
-sudo apt-get install amulet -y

--- a/tests/10-deploy
+++ b/tests/10-deploy
@@ -9,7 +9,7 @@ class TestDeployment(unittest.TestCase):
     def setUpClass(cls):
         cls.d = amulet.Deployment(series='xenial')
         cls.d.add('etcd')
-        cls.d.setup(timeout=900)
+        cls.d.setup(timeout=1200)
         cls.d.sentry.wait()
         cls.etcd = cls.d.sentry['etcd']
         # find the leader
@@ -28,7 +28,7 @@ class TestDeployment(unittest.TestCase):
         application.'''
         # Ensure we aren't testing a single node
         if not len(self.etcd) > 1:
-            self.d.add_unit('etcd')
+            self.d.add_unit('etcd', timeout=1200)
             self.d.sentry.wait()
 
         for unit in self.etcd:

--- a/unit_tests/test_etcdctcl.py
+++ b/unit_tests/test_etcdctcl.py
@@ -22,7 +22,7 @@ class TestEtcdCtl:
                                      'member',
                                      'add',
                                      'etcd0',
-                                     'http://127.0.0.1:1313'])  # noqa
+                                     'https://127.0.0.1:1313'])  # noqa
 
     def test_unregister(self):
         with patch('etcdctl.check_output') as spcm:


### PR DESCRIPTION
Removes the 00-setup in favor of tests.yaml
Adds timeout values to add_unit, and bumps them up for slow clouds
