### PR TITLE
move (leader) to end of message for uniformity

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -425,5 +425,5 @@ def status_set(status, message):
     ''' This is a fun little hack to give me the leader in status output
         without taking it over '''
     if is_leader():
-        message = "(leader) {}".format(message)
+        message = "{} (leader)".format(message)
     hess(status, message)


### PR DESCRIPTION
Currently output looks like this:

```
etcd/0        active    idle   0        172.27.24.51    2379/tcp  cluster is healthy
etcd/1        active    idle   1        172.27.24.52    2379/tcp  (leader) cluster is healthy
etcd/2        active    idle   2        172.27.24.53    2379/tcp  cluster is healthy
```

Now it looks like:

```
etcd/0        active    idle   0        172.27.24.51    2379/tcp  cluster is healthy
etcd/1        active    idle   1        172.27.24.52    2379/tcp  cluster is healthy (leader)
etcd/2        active    idle   2        172.27.24.53    2379/tcp  cluster is healthy
```
