### PR TITLE
Moved 10-deploy to 10-deploy.py

### DIFF
--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -2,6 +2,7 @@
 
 import amulet
 import unittest
+import re
 
 
 class TestDeployment(unittest.TestCase):
@@ -10,7 +11,9 @@ class TestDeployment(unittest.TestCase):
         cls.d = amulet.Deployment(series='xenial')
         cls.d.add('etcd')
         cls.d.setup(timeout=1200)
-        cls.d.sentry.wait()
+        cls.d.sentry.wait_for_messages({'etcd':
+                                        re.compile('Healthy*|Unhealthy*')})
+        # cls.d.sentry.wait()
         cls.etcd = cls.d.sentry['etcd']
         # find the leader
         for unit in cls.etcd:


### PR DESCRIPTION
The default behavior of the sentry.wait() method was causing some false
positives in CWR. I've switched over to wait_for_messages() to sniff out
the ETCD deployment status and only proceed once Healthy/Unhealthy has
been reported.

One might argue why I didn't only decorate for healthy. I feel that the
output of the tests is still going to be helpful in determining the
severity of the failure, and might give insight into why the deployment
is unhealthy.
