### PR TITLE
Adds the snapshot action

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,23 @@ export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
 etcdctl member list
 ```
 
+# Operational Actions
+
+### Snapshot
+
+Allows the operator to snapshot a running clusters data for use in cloning,
+backing up, or migrating Etcd clusters. 
+
+```
+juju run-action etcd/0 snapshot target=/mnt/etcd-backups
+```
+
+- **param** target: destination directory to save the resulting snapshot archive.
 
 # Known Limitations
 
-If you destroy the leader - identified with the `(leader)` text prepended to
-any status messages: all TLS pki will be lost. No PKI migration occurs outside
+If you destroy the leader - identified with the `*` text next to the unit number:
+all TLS pki will be lost. No PKI migration occurs outside
 of the units requesting and registering the certificates. You have been warned.
 
 Additionally, this charm breaks with no backwords compat/upgrade path at the trusty/xenial

--- a/actions.yaml
+++ b/actions.yaml
@@ -4,3 +4,10 @@ package-client-credentials:
     description: |
      Generate a tarball of the client certificates to connect to the cluster
      remotely.
+snapshot:
+  description: Export and compress a backup of the data in the Etcd cluster.
+  params:
+    target:
+      type: string
+      default: '/home/ubuntu/etcd-snapshots'
+      description: Location to save the etcd snapshot.

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+# Snippet from: https://coreos.com/etcd/docs/latest/admin_guide.html
+# Snapshot a running etcd cluster data.
+# This command will rewrite some of the metadata contained in the backup
+# (specifically, the node ID and cluster ID), which means that the node will
+# lose its former identity. In order to recreate a cluster from the backup, you
+# will need to start a new, single-node cluster. The metadata is rewritten to
+# prevent the new node from inadvertently being joined onto an existing cluster.
+
+ETCD_BACKUP_TARGET_DIR=$(action-get target)
+ETCD_DATA_DIR=/var/lib/etcd/default
+DATE_STAMP=$(date +%Y-%m-%d-%H.%M.%S)
+ARCHIVE=etcd-snapshot-$DATE_STAMP.tar.gz
+
+# Ensure the backupd target exists
+mkdir -p $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_ID
+
+# Dump the data currently in the cluster
+etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+
+# Create the backup archive
+cd $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+tar cvfz ../$ARCHIVE .
+
+# keep things tidy
+cd ..
+rm -rf $JUJU_ACTION_UUID
+
+action-set snapshot.path="$ETCD_BACKUP_TARGET_DIR/$ARCHIVE"
+action-set snapshot.size="$(du -h $ETCD_BACKUP_TARGET_DIR/$ARCHIVE | cut -d$'\t' -f1)"
+action-set snapshot.sha256="$(sha256sum $ETCD_BACKUP_TARGET_DIR/$ARCHIVE | cut -d' ' -f1)"
+action-set copy.cmd="juju scp $JUJU_UNIT_NAME:$ETCD_BACKUP_TARGET_DIR/$ARCHIVE ."


### PR DESCRIPTION
Half of the puzzle of migrating etcd. The snapshot action allows a
cluster admin to export a point-in-time snapshot of the etcd data
residing in the cluster.

Only a single node will need to export its data, and only a single node
can re-import and start a new cluster. For more information about this
process see: https://coreos.com/etcd/docs/latest/admin_guide.html

related to #58 