### PR TITLE
Adds the restore action

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ is healthy, you may resume scaling the application to meet your needs.
 
 - **param** skip-backup: Don't backup any existing data.
 
+### Snapshot
+
+Allows the operator to snapshot a running clusters data for use in cloning,
+backing up, or migrating Etcd clusters.
+
+```
+juju run-action etcd/0 snapshot target=/mnt/etcd-backups
+```
+
+- **param** target: destination directory to save the resulting snapshot archive.
+
+
 
 # Migrating etcd
 
@@ -179,8 +191,8 @@ Step 5: Scale and operate as required
 # Known Limitations
 
 #### Loss of PKI warning
-If you destroy the leader - identified with the `(leader)` text prepended to
-any status messages: all TLS pki will be lost. No PKI migration occurs outside
+If you destroy the leader - identified with the `*` text next to the unit number:
+all TLS pki will be lost. No PKI migration occurs outside
 of the units requesting and registering the certificates.
 
 > Important:  Mismanaging this configuration will result in locking yourself
@@ -195,8 +207,8 @@ due to the nature of peer relationships, and how the certificates are generated/
 
 To migrate from Trusty to Xenial, the operator will be responsible for deploying the
 Xenial etcd cluster, then issuing an etcd data dump on the trusty series, and importing
-that data into the new cluster. This can be performed on a single node due to the
-nature of how replicas work in Etcd.
+that data into the new cluster. This can be only be performed on a single node
+due to the nature of how replicas work in Etcd.
 
 Any issues with the above process should be filed against the charm layer in github.
 

--- a/README.md
+++ b/README.md
@@ -122,13 +122,12 @@ juju deploy etcd new-etcd
 
 > The above code snippet will deploy a single unit of etcd, as 'new-etcd'
 
-Once the restore action has completed, evaluate the cluster health. If the unit
-is healthy, you may resume scaling the application to meet your needs.
-
-
 ```
 juju run-action etcd/0 restore target=/mnt/etcd-backups
 ```
+
+Once the restore action has completed, evaluate the cluster health. If the unit
+is healthy, you may resume scaling the application to meet your needs.
 
 - **param** target: destination directory to save the existing data.
 

--- a/actions.yaml
+++ b/actions.yaml
@@ -11,3 +11,15 @@ snapshot:
       type: string
       default: '/home/ubuntu/etcd-snapshots'
       description: Location to save the etcd snapshot.
+restore:
+  description: Restore an etcd cluster's data from a snapshot tarball.
+  params:
+    target:
+      type: string
+      default: '/home/ubuntu'
+      description: Path on disk to save any pre-existing data.
+    skip-backup:
+      type: boolean
+      default: true
+      description: |
+        Dont backup any existing data, and skip directly to data restoration.

--- a/actions/restore
+++ b/actions/restore
@@ -9,7 +9,9 @@ set -ex
 # cluster node, in a new state. Restoration of existing cluster state is not
 # supported at this time.
 
+# this annoys my OCD
 DATESTAMP=$(date +%Y-%m-%d-%H.%M.%S)
+
 ARCHIVE=etcd-data-$DATESTAMP.tar.gz
 ETCD_DATA_DIR=/var/lib/etcd
 ETCD_PORT=$(config-get management_port)
@@ -40,6 +42,8 @@ then
   then
     juju-log "Backing up existing data found in $ETCD_DATA_DIR"
     tar cvf $TARGET_PATH/$ARCHIVE default
+    action-set backup.path="$TARGET_PATH/$ARCHIVE"
+    action-set backup.sha256sum=$(sha256sum $TARGET_PATH/$ARCHIVE | cut -d' ' -f1)
   fi
   rm -rf default
   mkdir default
@@ -49,7 +53,8 @@ fi
 juju-log "Stopping Etcd to perform the restore."
 systemctl stop etcd
 
-# Give systemd and etcd a couple seconds to catch up
+# Give systemd and etcd a couple seconds to catch up. systemctl is blocking
+# so this is likely uneccesary other than ensuring we're not racing.
 sleep 3
 
 # Unpack the resource
@@ -58,15 +63,28 @@ chown -R etcd:etcd $ETCD_DATA_DIR
 
 # Fork and start the etcd node in the background to drop any peer/client information
 etcd -data-dir=$ETCD_DATA_DIR/default -wal-dir=$ETCD_DATA_DIR/default/member/wal -force-new-cluster &
-# give it a few seconds to do some initialization
-sleep 5
+
+# Get persinickety about the error state here, as this will fail if we race with
+# systemd and etcd.
+set +x
+until etcdctl member list | grep "http://localhost"; do
+  sleep 1
+done
+set -x
+
 # Reconfigure the data-store peer-url on the fly. This will fail if there are
 # more than a single unit. #TODO Make this more robust. This was necessary when
 # scaling the unit. The new-init seems to be over-riding the advertise flags set
 # in the defaults file.
 ETCD_CLUSTER_UNIT_ID=$(etcdctl member list | cut -d ':' -f1)
 etcdctl member update $ETCD_CLUSTER_UNIT_ID https://$PRIVATE_ADDRESS:$ETCD_PORT
-sleep 3
+
+until etcdctl member list | grep "https://$PRIVATE_ADDRESS:$ETCD_PORT"; do
+  juju-log "Waiting on etcd peer url configuration to propigate"
+  # give this a bit of a longer timeout to ensure the data has settled once we
+  # break
+  sleep 5
+done
 # terminate the instance and resume normal operation
 pkill etcd
 

--- a/actions/restore
+++ b/actions/restore
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -ex
+
+# This is an encapsulation of the "Restoring a Backup" section of the Etcd
+# administration guide located here: https://coreos.com/etcd/docs/latest/admin_guide.html
+#
+# Note: That restoration of a clusters data *must* be performed on a single etcd
+# cluster node, in a new state. Restoration of existing cluster state is not
+# supported at this time.
+
+ARCHIVE=etcd-data-$DATESTAMP.tar.gz
+DATESTAMP=$(date +%Y-%m-%d-%H.%M.%S)
+ETCD_DATA_DIR=/var/lib/etcd
+ETCD_PORT=$(config-get management_port)
+PRIVATE_ADDRESS=$(unit-get private-address)
+SNAPSHOT_ARCHIVE=$(resource-get snapshot)
+TARGET_PATH=$(action-get target)
+
+# Having a snapshot loaded in the resource stream is mandatory for a Restore
+# to function.
+if [ -z "${SNAPSHOT_ARCHIVE}" ]
+then
+  action-set result.failed="Missing snapshot archive. See: README.md"
+  exit 0
+fi
+
+# Check for the existence of an existing cluster data-store. This will be
+# true 99% of the time, as even new clusters installed from apt seem to initialize
+# some form of data-store
+
+if [ -d $ETCD_DATA_DIR/default ]
+then
+  juju-log "Backing up existing data found in $ETCD_DATA_DIR"
+  cd $ETCD_DATA_DIR
+  # might cause the action to fail, but not sure if its better to get the output
+  # or to set a message and irritate the user, or just blindly delete their data.
+  tar cvf $TARGET_PATH/$ARCHIVE default
+  rm -rf default
+  mkdir default
+  cd $CHARM_DIR
+fi
+
+juju-log "Stopping Etcd to perform the restore."
+systemctl stop etcd
+
+# Give systemd and etcd a couple seconds to catch up
+sleep 3
+
+# Unpack the resource
+tar xvfz $SNAPSHOT_ARCHIVE -C $ETCD_DATA_DIR/default
+chown -R etcd:etcd $ETCD_DATA_DIR
+
+# Fork and start the etcd node in the background to drop any peer/client information
+etcd -data-dir=$ETCD_DATA_DIR/default -wal-dir=$ETCD_DATA_DIR/default/member/wal -force-new-cluster &
+# give it a few seconds to do some initialization
+sleep 5
+# Reconfigure the data-store peer-url on the fly. This will fail if there are
+# more than a single unit. #TODO Make this more robust. This was necessary when
+# scaling the unit. The new-init seems to be over-riding the advertise flags set
+# in the defaults file.
+ETCD_CLUSTER_UNIT_ID=$(etcdctl member list | cut -d ':' -f1)
+etcdctl member update $ETCD_CLUSTER_UNIT_ID https://$PRIVATE_ADDRESS:$ETCD_PORT
+sleep 3
+# terminate the instance and resume normal operation
+pkill etcd
+
+systemctl restart etcd

--- a/actions/restore
+++ b/actions/restore
@@ -9,11 +9,12 @@ set -ex
 # cluster node, in a new state. Restoration of existing cluster state is not
 # supported at this time.
 
-ARCHIVE=etcd-data-$DATESTAMP.tar.gz
 DATESTAMP=$(date +%Y-%m-%d-%H.%M.%S)
+ARCHIVE=etcd-data-$DATESTAMP.tar.gz
 ETCD_DATA_DIR=/var/lib/etcd
 ETCD_PORT=$(config-get management_port)
 PRIVATE_ADDRESS=$(unit-get private-address)
+SKIP_BACKUP=$(action-get skip-backup)
 SNAPSHOT_ARCHIVE=$(resource-get snapshot)
 TARGET_PATH=$(action-get target)
 
@@ -31,11 +32,15 @@ fi
 
 if [ -d $ETCD_DATA_DIR/default ]
 then
-  juju-log "Backing up existing data found in $ETCD_DATA_DIR"
   cd $ETCD_DATA_DIR
+
   # might cause the action to fail, but not sure if its better to get the output
   # or to set a message and irritate the user, or just blindly delete their data.
-  tar cvf $TARGET_PATH/$ARCHIVE default
+  if [ "${SKIP_BACKUP}" != 'true' ]
+  then
+    juju-log "Backing up existing data found in $ETCD_DATA_DIR"
+    tar cvf $TARGET_PATH/$ARCHIVE default
+  fi
   rm -rf default
   mkdir default
   cd $CHARM_DIR

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,13 +6,6 @@ description: |
   This charm supports deploying Etcd from the upstream binaries with resources.
   It will also TLS wrap your service, and distribute client keys to any service
   connecting. Etcd is a highly available key/value store.
-tags:
-  - database
-  - keystore
-  - layer
-series:
-  - xenial
-subordinate: false
 provides:
   db:
     interface: etcd
@@ -21,3 +14,15 @@ provides:
 peers:
   cluster:
     interface: etcd
+resources:
+  snapshot:
+    type: file
+    filename: snapshot.tar.gz
+    description: Tarball snapshot of an etcd clusters data.
+series:
+  - xenial
+subordinate: false
+tags:
+  - database
+  - keystore
+  - layer


### PR DESCRIPTION
This adds the capability of the etcd charm to restore the state of an
etcd cluster created from the `snapshot` action. The process is
documented on the etcd admin guide:
https://coreos.com/etcd/docs/latest/admin_guide.html

Note: that restoring from a snapshot is only supported on new clusters,
as restoring from a snapshot on a scaled cluster can yield a broken
installation. Peers are dropped and the cluster ID is changed during new
cluster initialization.


Once #59 is merged, this branch likely wont apply cleanly. I'll rebase and clean up the merge so it will pass post initial review.

This work is marginally hand tested, with no automated tests at the moment. I'll try to land those by tomorrow afternoon. Related to https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/126