### PR TITLE
Layer tls-client rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@ build:
 	charm build -r --no-local-layers
 
 deploy: build
-	juju deploy cs:~containers/easyrsa
 	juju deploy ${JUJU_REPOSITORY}/builds/etcd
+	juju deploy cs:~containers/easyrsa
 	juju add-relation etcd easyrsa
+
+lint:
+	flake8 reactive lib
 
 upgrade: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd
@@ -13,3 +16,12 @@ upgrade: build
 force: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd --force-units
 
+test: build
+	tox -c ${JUJU_REPOSITORY}/builds/etcd/tox.ini
+
+clean:
+	rm -rf .tox
+	rm -f .coverage
+
+clean-all: clean
+	rm -rf ${JUJU_REPOSITORY}/builds/etcd

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+
+build:
+	charm build -r --no-local-layers
+
+deploy: build
+	juju deploy cs:~containers/easyrsa
+	juju deploy ${JUJU_REPOSITORY}/builds/etcd
+	juju add-relation etcd easyrsa
+
+upgrade: build
+	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd
+
+force: build
+	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd --force-units
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deploy: build
 	juju add-relation etcd easyrsa
 
 lint:
-	flake8 reactive lib
+	/usr/bin/python3 -m flake8 reactive lib
 
 upgrade: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd
@@ -16,7 +16,7 @@ upgrade: build
 force: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd --force-units
 
-test: build
+test-convoluted: build
 	tox -c ${JUJU_REPOSITORY}/builds/etcd/tox.ini
 
 clean:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ observation.
 We can deploy a single node easily with
 
 ```shell
+juju deploy easyrsa
 juju deploy etcd
+juju add-relation etcd easyrsa
 ```
 And add capacity with:
 
@@ -87,9 +89,9 @@ and export some environment variables to consume the client credentials.
 
 ```shell
 juju expose etcd
-export ETCDCTL_KEY_FILE=$(pwd)/clientkey.pem
-export ETCDCTL_CERT_FILE=$(pwd)/clientcert.pem
-export ETCDCTL_CA_FILE=$(pwd)/ca.pem
+export ETCDCTL_KEY_FILE=$(pwd)/client.key
+export ETCDCTL_CERT_FILE=$(pwd)/client.crt
+export ETCDCTL_CA_FILE=$(pwd)/ca.crt
 export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
 etcdctl member list
 ```
@@ -232,15 +234,6 @@ Step 5: Scale and operate as required
 
 # Known Limitations
 
-#### Loss of PKI warning
-If you destroy the leader - identified with the `*` text next to the unit number:
-all TLS pki will be lost. No PKI migration occurs outside
-of the units requesting and registering the certificates.
-
-> Important:  Mismanaging this configuration will result in locking yourself
-> out of the cluster, and can potentially break existing deployments in very
-> strange ways relating to x509 validation of certificates, which affects both
-> servers and clients.
 
 #### TLS Defaults Warning (for trusty etcd charm users)
 Additionally, this charm breaks with no backwards compat/upgrade path at the Trusty/Xenial

--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -4,9 +4,10 @@
 
 mkdir -p etcd_credentials
 
-leader-get client_certificate > etcd_credentials/clientcert.pem
-leader-get client_key > etcd_credentials/clientkey.pem
-leader-get certificate_authority > etcd_credentials/ca.pem
+
+cp /etc/ssl/etcd/client.crt etcd_credentials/client.crt
+cp /etc/ssl/etcd/client.key etcd_credentials/client.key
+cp /etc/ssl/etcd/ca.crt etcd_credentials/ca.crt
 
 # Render a README heredoc
 cat << EOF > etcd_credentials/README.txt
@@ -25,10 +26,10 @@ practice to leave it firewalled from the world unless you have need of an
 exposed etcd endpoint.
 
   juju expose etcd
-  export ETCDCTL_KEY_FILE=$(pwd)/clientkey.pem
-  export ETCDCTL_CERT_FILE=$(pwd)/clientcert.pem
-  export ETCDCTL_CA_FILE=$(pwd)/ca.pem
-  export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
+  export ETCDCTL_KEY_FILE=$(pwd)/client.key
+  export ETCDCTL_CERT_FILE=$(pwd)/client.crt
+  export ETCDCTL_CA_FILE=$(pwd)/ca.crt
+  export ETCDCTL_ENDPOINT=https://$(unit-get public-address):2379
   etcdctl member list
 
 If you have any trouble regarding connecting to your Etcd cluster, don't
@@ -38,3 +39,4 @@ EOF
 
 tar cfz etcd_credentials.tar.gz etcd_credentials
 cp etcd_credentials.tar.gz /home/ubuntu/
+rm -rf etcd_credentials

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,12 +1,23 @@
 repo: https://github.com/juju-solutions/layer-etcd.git
 includes:
   - 'layer:basic'
-  - 'layer:tls'
+  - 'layer:tls-client'
   - 'layer:leadership'
   - 'interface:etcd'
   - 'interface:etcd-proxy'
 ignore:
   - tests
+defines:
+  tls_backup_path:
+    type: string
+    default: /home/ubuntu/etcd-tls-backup
+    description: The absolute path to store any tls_certificate backups.
 options:
   basic:
     packages: ['rsync']
+  tls-client:
+    ca_certificate_path: /etc/ssl/etcd/ca.crt
+    server_certificate_path: /etc/ssl/etcd/server.crt
+    server_key_path: /etc/ssl/etcd/server.key
+    client_certificate_path: /etc/ssl/etcd/client.crt
+    client_certificate_key: /etc/ssl/etcd/client.key

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,8 +5,6 @@ includes:
   - 'layer:leadership'
   - 'interface:etcd'
   - 'interface:etcd-proxy'
-ignore:
-  - tests
 defines:
   tls_backup_path:
     type: string
@@ -15,6 +13,8 @@ defines:
 options:
   basic:
     packages: ['rsync']
+# These options are mirrored in the test suite as hard-coded values.
+# If these cert locations change, please update the test suite accordingly
   tls-client:
     ca_certificate_path: /etc/ssl/etcd/ca.crt
     server_certificate_path: /etc/ssl/etcd/server.crt

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,11 +5,6 @@ includes:
   - 'layer:leadership'
   - 'interface:etcd'
   - 'interface:etcd-proxy'
-defines:
-  tls_backup_path:
-    type: string
-    default: /home/ubuntu/etcd-tls-backup
-    description: The absolute path to store any tls_certificate backups.
 options:
   basic:
     packages: ['rsync']

--- a/layer.yaml
+++ b/layer.yaml
@@ -20,4 +20,4 @@ options:
     server_certificate_path: /etc/ssl/etcd/server.crt
     server_key_path: /etc/ssl/etcd/server.key
     client_certificate_path: /etc/ssl/etcd/client.crt
-    client_certificate_key: /etc/ssl/etcd/client.key
+    client_key_path: /etc/ssl/etcd/client.key

--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -1,3 +1,4 @@
+from charms import layer
 from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import is_leader
@@ -20,9 +21,9 @@ class EtcdDatabag:
      'unit_name': 'etcd0',
      'port': '2380',
      'management_port': '2379',
-     'ca_certificate': '/etc/ssl/etcd/ca.pem',
-     'server_certificate': '/etc/ssl/etcd/server.pem',
-     'server_key': '/etc/ssl/etcd/server-key.pem',
+     'ca_certificate': '/etc/ssl/etcd/ca.crt',
+     'server_certificate': '/etc/ssl/etcd/server.crt',
+     'server_key': '/etc/ssl/etcd/server.key',
      'token': '8XG27B',
      'cluster_state': 'existing'}
     '''
@@ -36,10 +37,16 @@ class EtcdDatabag:
         self.private_address = unit_get('private-address')
         self.unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '')
 
-        # These are hard coded, smell for now.
-        self.ca_certificate = "/etc/ssl/etcd/ca.pem"
-        self.server_certificate = "/etc/ssl/etcd/server.pem"
-        self.server_key = "/etc/ssl/etcd/server-key.pem"
+        # Pull the TLS certificate paths from layer data
+        opts = layer.options('tls-client')
+        ca_path = opts['ca_certificate_path']
+        crt_path = opts['server_certificate_path']
+        key_path = opts['server_key_path']
+
+        self.ca_certificate = ca_path
+        self.server_certificate = crt_path
+        self.server_key = key_path
+
         # Cluster concerns
         self.token = self.cluster_token()
         self.cluster_state = 'existing'

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -134,7 +134,7 @@ class EtcdCtl:
         crt_path = opts['server_certificate_path']
         key_path = opts['server_key_path']
         os.environ['ETCDCTL_CA_FILE'] = ca_path
-        os.environ['ETCDCTL_CERT_FILE'] = crt_path 
+        os.environ['ETCDCTL_CERT_FILE'] = crt_path
         os.environ['ETCDCTL_KEY_FILE'] = key_path
         return check_output(split(command)).decode('ascii')
 

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -1,3 +1,4 @@
+from charms import layer
 from charmhelpers.core.hookenv import log
 from subprocess import CalledProcessError
 from shlex import split
@@ -128,9 +129,13 @@ class EtcdCtl:
     def run(self, command):
         ''' Wrapper to subprocess calling output. This is a convenience
         method to clean up the calls to subprocess and append TLS data'''
-        os.environ['ETCDCTL_CA_FILE'] = '/etc/ssl/etcd/ca.pem'
-        os.environ['ETCDCTL_CERT_FILE'] = '/etc/ssl/etcd/server.pem'
-        os.environ['ETCDCTL_KEY_FILE'] = '/etc/ssl/etcd/server-key.pem'
+        opts = layer.options('tls-client')
+        ca_path = opts['ca_certificate_path']
+        crt_path = opts['server_certificate_path']
+        key_path = opts['server_key_path']
+        os.environ['ETCDCTL_CA_FILE'] = ca_path
+        os.environ['ETCDCTL_CERT_FILE'] = crt_path 
+        os.environ['ETCDCTL_KEY_FILE'] = key_path
         return check_output(split(command)).decode('ascii')
 
 

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -109,7 +109,7 @@ def spam_ownership_of_tls_certs():
         # certs are in the basepath of the server certificate
         opts = layer.options('tls-client')
         cert_dir = os.path.dirname(opts['server_certificate_path'])
-        check_call(['chown', '-R', 'etcd:root', cert_dir])
+        check_call(['chown', '-R', 'etcd:ubuntu', cert_dir])
         set_state('etcd.ssl.placed')
     except CalledProcessError:
         log('Failed to change ownership of TLS certificates.')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -186,9 +186,9 @@ def follower_config_changed():
 def send_cluster_connection_details(cluster, db):
     ''' Need to set the cluster connection string and
     the client key and certificate on the relation object. '''
-    cert = read_tls_cert('client_certificate')
-    key = read_tls_cert('client_key')
-    ca = read_tls_cert('certificate_authority')
+    cert = read_tls_cert('client.crt')
+    key = read_tls_cert('client.key')
+    ca = read_tls_cert('ca.crt')
 
     # Set the key, cert, and ca on the db relation
     db.set_client_credentials(key, cert, ca)

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -186,9 +186,9 @@ def follower_config_changed():
 def send_cluster_connection_details(cluster, db):
     ''' Need to set the cluster connection string and
     the client key and certificate on the relation object. '''
-    cert = leader_get('client_certificate')
-    key = leader_get('client_key')
-    ca = leader_get('certificate_authority')
+    cert = read_tls_cert('client_certificate')
+    key = read_tls_cert('client_key')
+    ca = read_tls_cert('certificate_authority')
 
     # Set the key, cert, and ca on the db relation
     db.set_client_credentials(key, cert, ca)
@@ -480,11 +480,11 @@ def read_tls_cert(cert):
     opts = layer.options('tls-client')
 
     # Retain a dict of the certificate paths
-    cert_paths = {'ca': opts['ca_certificate_path'],
+    cert_paths = {'ca.crt': opts['ca_certificate_path'],
                   'server.crt': opts['server_certificate_path'],
                   'server.key': opts['server_key_path'],
-                  'client.crt': opts['client_certificate'],
-                  'client.key': opts['client_certificate_key']}
+                  'client.crt': opts['client_certificate_path'],
+                  'client.key': opts['client_key_path']}
 
     # If requesting a cert we dont know about, raise a ValueError
     if cert not in cert_paths.keys():
@@ -492,7 +492,7 @@ def read_tls_cert(cert):
 
     # Read the contents of the cert and return it in utf-8 encoded text
     with open(cert_paths[cert], 'r') as fp:
-        data = fp.read().decode('utf-8')
+        data = fp.read()
         return data
 
 

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -51,9 +51,10 @@ class TestDeployment(unittest.TestCase):
         ''' Test we have the same number of units deployed and reporting in
         the etcd cluster as participating'''
 
-        certs = "ETCDCTL_KEY_FILE=/etc/ssl/etcd/server-key.pem " \
-                " ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.pem" \
-                " ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.pem"
+        # The spacing here is semi-important as its a string of ENV exports
+        certs = "ETCDCTL_KEY_FILE=/etc/ssl/etcd/server.key " \
+                " ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.crt" \
+                " ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.crt"
 
         # format the command, and execute on the leader
         out = self.leader.run('{} etcdctl member list'.format(certs))[0]

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -10,6 +10,8 @@ class TestDeployment(unittest.TestCase):
     def setUpClass(cls):
         cls.d = amulet.Deployment(series='xenial')
         cls.d.add('etcd')
+        cls.d.add('easyrsa', 'cs:~containers/easyrsa')
+        cls.d.relate('easyrsa:client', 'etcd:certificates')
         cls.d.setup(timeout=1200)
         cls.d.sentry.wait_for_messages({'etcd':
                                         re.compile('Healthy*|Unhealthy*')})
@@ -52,6 +54,8 @@ class TestDeployment(unittest.TestCase):
         the etcd cluster as participating'''
 
         # The spacing here is semi-important as its a string of ENV exports
+        # also, this is hard coding for the defaults. if the defaults in
+        # layer.yaml change, this will need to change.
         certs = "ETCDCTL_KEY_FILE=/etc/ssl/etcd/server.key " \
                 " ETCDCTL_CERT_FILE=/etc/ssl/etcd/server.crt" \
                 " ETCDCTL_CA_FILE=/etc/ssl/etcd/ca.crt"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -2,3 +2,5 @@ tests: "10-*"
 packages:
   - amulet
 reset: false
+makefile:
+  - lint

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
     flake8
     mock
     pytest-cov
-    pytest-capturelog
     pytest
 
 commands =
+  flake8 reactive lib
   py.test -v {posargs} --cov=lib --cov-report=term-missing


### PR DESCRIPTION
Initial rework + minor validation of server side changes.

    This replaces the aging tls-layer code with layer-tls-client certificate
    management. This is a clean wipe + redeploy path implementation, and does
    not fully satisfy the TLS rework task.

    This only covers server => server communication pipelines. There is
    additional logic leftover for client => server and proxy => server
    communication paths that will need to be updated and addressed accordingly.
    Namely not relying on leader_data to hand off certificate information.

This branch when merged will close #50, #46, and #45