### PR TITLE
Fixes for #66

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+dist: trusty
+sudo: required
 language: python
 python:
  - '3.5'
 
 install:
  - pip install tox
+ - sudo add-apt-repository -y ppa:juju/stable
+ - sudo apt-get update
+ - sudo apt-get install -y charm-tools
 
 script:
- - tox
+ - make test-convoluted

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ upgrade: build
 force: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd --force-units
 
-test-convoluted: build
-	tox -c ${JUJU_REPOSITORY}/builds/etcd/tox.ini
+test-convoluted:
+	charm build -o tmp -r --no-local-layers
+	tox -c tmp/builds/etcd/tox.ini
+	rm -rf tmp
 
 clean:
 	rm -rf .tox


### PR DESCRIPTION
Moves the install routine to the travis yaml, and builds to a temporary
path in PWD, then executes the tox tests