### PR TITLE
Send etcd version on the wire with connection details

### DIFF
--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -141,6 +141,18 @@ class EtcdCtl:
         os.environ['ETCDCTL_KEY_FILE'] = key_path
         return check_output(split(command)).decode('ascii')
 
+    def version(self):
+        ''' Return the version of etcdctl '''
+        version = ''
+        out = self.run('{} --version'.format(self.ETCDCTL_COMMAND))
+
+        for line in out.split('\n'):
+            if 'etcdctl' in line:
+                # Note: version 2 does not contain any : so split on version
+                # and handle etcd 3+ output accordingly.
+                version = line.split('version')[-1].replace(':', '').strip()
+        return version
+
 
 def get_connection_string(members, port, protocol='https'):
     ''' Return a connection string for the list of members using the provided

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -173,6 +173,7 @@ def send_cluster_connection_details(cluster, db):
     cert = read_tls_cert('client.crt')
     key = read_tls_cert('client.key')
     ca = read_tls_cert('ca.crt')
+    etcdctl = EtcdCtl()
 
     # Set the key, cert, and ca on the db relation
     db.set_client_credentials(key, cert, ca)
@@ -183,7 +184,7 @@ def send_cluster_connection_details(cluster, db):
     # Create a connection string with all the members on the configured port.
     connection_string = get_connection_string(members, port)
     # Set the connection string on the db relation.
-    db.set_connection_string(connection_string)
+    db.set_connection_string(connection_string, version=etcdctl.version())
 
 
 @when('db.connected')
@@ -193,6 +194,9 @@ def send_single_connection_details(db):
     cert = read_tls_cert('client.crt')
     key = read_tls_cert('client.key')
     ca = read_tls_cert('ca.crt')
+
+    etcdctl = EtcdCtl()
+
     # Set the key and cert on the db relation
     db.set_client_credentials(key, cert, ca)
 
@@ -202,7 +206,7 @@ def send_single_connection_details(db):
     # Create a connection string with this member on the configured port.
     connection_string = get_connection_string(members, bag.port)
     # Set the connection string on the db relation.
-    db.set_connection_string(connection_string)
+    db.set_connection_string(connection_string, version=etcdctl.version())
 
 
 @when('proxy.connected')

--- a/unit_tests/test_etcdctl.py
+++ b/unit_tests/test_etcdctl.py
@@ -42,6 +42,34 @@ class TestEtcdCtl:
             assert(members['etcd22']['client_urls'] == 'https://10.113.96.220:2379')  # noqa
 
     def test_member_list_with_unstarted_member(self):
+        ''' Validate we receive information only about members we can parse
+        from the current status string '''
         # 57fa5c39949c138e[unstarted]: peerURLs=http://10.113.96.80:2380
         # bb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379  # noqa
-        pass
+        with patch('etcdctl.check_output') as comock:
+            comock.return_value = b'57fa5c39949c138e[unstarted]: peerURLs=http://10.113.96.80:2380]\nbb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379\n'  # noqa
+            members = self.etcdctl().member_list()
+            assert(members['etcd9']['unit_id'] == 'bb0f83ebb26386f7')
+            assert(members['etcd9']['peer_urls'] == 'https://10.113.96.178:2380')  # noqa
+            assert(members['etcd9']['client_urls'] == 'https://10.113.96.178:2379')  # noqa
+            assert('unstarted' in members.keys())
+            assert(members['unstarted'] == {})
+
+    def test_etcd_v2_version(self):
+        ''' Validate that etcdctl can parse versions for both etcd v2 and
+        etcd v3 '''
+        # Define fixtures of what we expect for the version output
+        etcdctl_2_version = b"etcdctl version 2.3.8\n"
+
+        with patch('etcdctl.check_output') as comock:
+            comock.return_value = etcdctl_2_version
+            ver = self.etcdctl().version()
+            assert(ver == '2.3.8')
+
+    def test_etcd_v3_version(self):
+        ''' Validate that etcdctl can parse version for etcdctl v3 '''
+        etcdctl_3_version = b"etcdctl version: 3.0.17\nAPI version: 2\n"
+        with patch('etcdctl.check_output') as comock:
+            comock.return_value = etcdctl_3_version
+            ver = self.etcdctl().version()
+            assert(ver == '3.0.17')


### PR DESCRIPTION
Etcd v2 and v3 have different protocol requirements. It makes sense to
have the version sent along with the connection string so the consumer
application can configure itself appropriately by parsing from the
version identifier if its v2 or v3 specific.

Depends on https://github.com/juju-solutions/interface-etcd/pull/9