### PR TITLE
Resolve issues with cluster scale when removing the leader

### DIFF
--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -50,16 +50,22 @@ class EtcdCtl:
                 reg['cluster'] = line.split('="')[-1].rstrip('"')
         return reg
 
-    def unregister(self, unit_id):
+    def unregister(self, unit_id, leader_address=None):
         ''' Perform self deregistration during unit teardown
 
-        @params cluster_data - a dict of data to fill out the request to push
-        our deregister command to the leader. requires  keys: leader_address,
-        port, etcd_unit_guid
+        @params unit_id - the ID for the unit assigned by etcd. Obtainable from
+        member_list method.
 
-        The unit_id can be obtained from the EtcdDatabag dict
+        @params leader_address - The endpoint to communicate with the leader in
+        the event of self deregistration.
         '''
-        command = "{0} member remove {1}".format(self.ETCDCTL_COMMAND, unit_id)
+
+        if leader_address:
+            cmd = "{0} --endpoint {1} member remove {2}"
+            command = cmd.format(self.ETCDCTL_COMMAND, leader_address, unit_id)
+        else:
+            cmd = "{0} member remove {1}"
+            command = cmd.format(self.ETCDCTL_COMMAND, unit_id)
 
         return self.run(command)
 

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -81,6 +81,15 @@ class TestDeployment(unittest.TestCase):
             self.assertTrue('etcd cluster is unavailable' not in members)
         self.assertTrue(len(members) == len(self.etcd))
 
+    def test_node_scale_down_members(self):
+        ''' Scale the cluster down and ensure the cluster state is still
+        healthy '''
+        # Remove the leader
+        self.d.remove_unit(self.leader.info['unit_name'])
+        self.d.sentry.wait()
+        # re-use the cluster-health test to validate we are still healthy.
+        self.test_cluster_health()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This branch removes the erronious logic when tracking the -departed
relation states to remove all participating peers. Instead we are now
relying on the behavior of the -broken hook to only execute on the unit
that is being removed from the cluster. This may not be perfect but
works 100% better than the current implementation.

Resolves https://github.com/kubernetes/kubernetes/issues/43461