### PR TITLE
Fix nrpe service check

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -47,6 +47,12 @@ import time
 # References to this state will be wiped sometime within the next 10 releases
 # of the charm.
 
+
+# Override the default nagios shortname regex to allow periods, which we
+# need because our bin names contain them (e.g. 'snap.foo.daemon'). The
+# default regex in charmhelpers doesn't allow periods, but nagios itself does.
+nrpe.Check.shortname_re = '[\.A-Za-z0-9-_]+$'
+
 @when('etcd.installed')
 def snap_upgrade_notice():
     status_set('blocked', 'Manual migration required. http://bit.ly/2oznAUZ')
@@ -530,7 +536,7 @@ def initial_nrpe_config(nagios=None):
           'config.changed.nagios_servicegroups')
 def update_nrpe_config(unused=None):
     # List of systemd services that will be checked
-    services = ('etcd',)
+    services = ('snap.etcd.etcd',)
 
     # The current nrpe-external-master interface doesn't handle a lot of logic,
     # use the charm-helpers code for now.
@@ -547,7 +553,7 @@ def remove_nrpe_config(nagios=None):
     remove_state('nrpe-external-master.initial-config')
 
     # List of systemd services for which the checks will be removed
-    services = ('etcd',)
+    services = ('snap.etcd.etcd',)
 
     # The current nrpe-external-master interface doesn't handle a lot of logic,
     # use the charm-helpers code for now.

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -53,6 +53,7 @@ import time
 # default regex in charmhelpers doesn't allow periods, but nagios itself does.
 nrpe.Check.shortname_re = '[\.A-Za-z0-9-_]+$'
 
+
 @when('etcd.installed')
 def snap_upgrade_notice():
     status_set('blocked', 'Manual migration required. http://bit.ly/2oznAUZ')

--- a/unit_tests/test_etcdctl.py
+++ b/unit_tests/test_etcdctl.py
@@ -16,7 +16,7 @@ class TestEtcdCtl:
                                      'unit_name': 'etcd0',
                                      'management_port': '1313',
                                      'leader_address': 'http://127.1.1.1:1212'})  # noqa
-            spcm.assert_called_with(['/snap/bin/etcd.etcdctl',
+            spcm.assert_called_with(['etcdctl',
                                      '-C',
                                      'http://127.1.1.1:1212',
                                      'member',
@@ -28,7 +28,7 @@ class TestEtcdCtl:
         with patch('etcdctl.check_output') as spcm:
             self.etcdctl().unregister('br1212121212')
 
-            spcm.assert_called_with(['/snap/bin/etcd.etcdctl',
+            spcm.assert_called_with(['etcdctl',
                                      'member',
                                      'remove',
                                      'br1212121212'])


### PR DESCRIPTION
Adjust the system call to look for snap.etcd.etcd and add the 'allow
period' regex modification from the k8s charms.

Fixes #86