### PR TITLE
Use tox for `make lint` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ deploy: build
 	juju add-relation etcd easyrsa
 
 lint:
-	/usr/bin/python3 -m flake8 reactive lib
+	tox --notest
+	PATH=.tox/py34/bin:.tox/py35/bin flake8 reactive lib
 
 upgrade: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd


### PR DESCRIPTION
@chuckbutler This fixes bundletester failures against the etcd charm in environments where flake8 isn't installed (e.g. our build server):

```
DEBUG:runner:call ['/usr/bin/make', '-s', 'lint'] (cwd: /tmp/bundletester-9EsBhE/etcd)
DEBUG:runner:/usr/bin/python3: No module named flake8
DEBUG:runner:Makefile:11: recipe for target 'lint' failed
DEBUG:runner:make: *** [lint] Error 1
DEBUG:runner:Exit Code: 2
```