### PR TITLE
Remove the : from the search string for 2.x

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -628,7 +628,7 @@ def etcd_version():
         raw_output = check_output(cmd)
         lines = raw_output.split(b'\n')
         for line in lines:
-            if b'etcdctl version:' in line:
+            if b'etcdctl version' in line:
                 # etcdctl version: 3.0.17
                 # Strip and massage the output
                 version = line.split(b':')[-1].strip()


### PR DESCRIPTION
etcdctl 2.x doesn't have : in the version output