### PR TITLE
Tim thinks we need amulet, our ci server agrees.

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -2,3 +2,5 @@ tests: "10-*"
 reset: false
 makefile:
   - lint
+packages:
+  - amulet


### PR DESCRIPTION
This adds a package installation for amulet in the event the host
running the test does not have the python module for amulet installed.