### PR TITLE
Fix snapshot bug

### DIFF
--- a/actions/restore.py
+++ b/actions/restore.py
@@ -27,7 +27,11 @@ opts = layer.options('etcd')
 DATESTAMP = datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')
 ARCHIVE = "etcd-data-{}.tar.gz".format(DATESTAMP)
 
-ETCD_DATA_DIR = opts['etcd_data_dir']
+unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '')
+ETCD_DATA_DIR = '{}/{}.etcd'.format(opts['etcd_data_dir'], unit_name)
+if not os.path.isdir(ETCD_DATA_DIR):
+    ETCD_DATA_DIR = opts['etcd_data_dir']
+
 ETCD_PORT = config('management_port')
 PRIVATE_ADDRESS = unit_get('private-address')
 SKIP_BACKUP = action_get('skip-backup')
@@ -127,7 +131,7 @@ def stop_etcd():
 
     try:
         service_stop('etcd')
-        log('Stoppd service: etcd')
+        log('Stopped service: etcd')
     except:
         log('Failed to stop service: etcd')
 

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -13,7 +13,12 @@ set -ex
 ETCD_BACKUP_TARGET_DIR=$(action-get target)
 #ETCD_DATA_DIR=/var/lib/etcd/default
 UNIT_NAME=${JUJU_UNIT_NAME%%/*}
-ETCD_DATA_DIR=/var/snap/etcd/current/$UNIT_NAME$JUJU_MACHINE_ID.etcd/
+UNIT_NUM=${JUJU_UNIT_NAME#*/}
+ETCD_DATA_DIR=/var/snap/etcd/current/$UNIT_NAME$UNIT_NUM.etcd/
+if [ ! -d "$ETCD_DATA_DIR" ]; then
+  ETCD_DATA_DIR=/var/snap/etcd/current/
+fi
+
 DATE_STAMP=$(date +%Y-%m-%d-%H.%M.%S)
 ARCHIVE=etcd-snapshot-$DATE_STAMP.tar.gz
 

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -12,7 +12,8 @@ set -ex
 
 ETCD_BACKUP_TARGET_DIR=$(action-get target)
 #ETCD_DATA_DIR=/var/lib/etcd/default
-ETCD_DATA_DIR=/var/snap/etcd/current/
+UNIT_NAME=${JUJU_UNIT_NAME%%/*}
+ETCD_DATA_DIR=/var/snap/etcd/current/$UNIT_NAME$JUJU_MACHINE_ID.etcd/
 DATE_STAMP=$(date +%Y-%m-%d-%H.%M.%S)
 ARCHIVE=etcd-snapshot-$DATE_STAMP.tar.gz
 

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -24,23 +24,6 @@ class TestDeployment(unittest.TestCase):
             if leader_result[0] == 'True':
                 cls.leader = unit
 
-    def test_snapshot_restore(self):
-        """
-        Trigger snapshot and restore actions
-        """
-        action_id = self.etcd[0].run_action('snapshot')
-        outcome = self.d.action_fetch(action_id,
-                                      timeout=7200,
-                                      raise_on_timeout=True,
-                                      full_output=True)
-        self.assertEqual(outcome['status'], 'completed')
-        action_id = self.etcd[0].run_action('restore')
-        outcome = self.d.action_fetch(action_id,
-                                      timeout=7200,
-                                      raise_on_timeout=True,
-                                      full_output=True)
-        self.assertEqual(outcome['status'], 'completed')
-
     def test_leader_status(self):
         ''' Verify our leader is running the etcd daemon '''
         status = self.leader.run('systemctl is-active snap.etcd.etcd')

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -24,6 +24,23 @@ class TestDeployment(unittest.TestCase):
             if leader_result[0] == 'True':
                 cls.leader = unit
 
+    def test_snapshot_restore(self):
+        """
+        Trigger snapshot and restore actions
+        """
+        action_id = self.etcd[0].run_action('snapshot')
+        outcome = self.d.action_fetch(action_id,
+                                      timeout=7200,
+                                      raise_on_timeout=True,
+                                      full_output=True)
+        self.assertEqual(outcome['status'], 'completed')
+        action_id = self.etcd[0].run_action('restore')
+        outcome = self.d.action_fetch(action_id,
+                                      timeout=7200,
+                                      raise_on_timeout=True,
+                                      full_output=True)
+        self.assertEqual(outcome['status'], 'completed')
+
     def test_leader_status(self):
         ''' Verify our leader is running the etcd daemon '''
         status = self.leader.run('systemctl is-active snap.etcd.etcd')

--- a/tests/20-actions.py
+++ b/tests/20-actions.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import amulet
+import unittest
+import re
+
+
+class TestActions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.d = amulet.Deployment(series='xenial')
+        cls.d.add('etcd')
+        cls.d.add('easyrsa', 'cs:~containers/easyrsa')
+        cls.d.configure('etcd', {'channel': '3.0/stable'})
+        cls.d.relate('easyrsa:client', 'etcd:certificates')
+        cls.d.setup(timeout=1200)
+        cls.d.sentry.wait_for_messages({'etcd':
+                                        re.compile('Healthy*|Unhealthy*')})
+        # cls.d.sentry.wait()
+        cls.etcd = cls.d.sentry['etcd']
+
+    def test_snapshot_restore(self):
+        """
+        Trigger snapshot and restore actions
+        """
+        action_id = self.etcd[0].run_action('snapshot')
+        outcome = self.d.action_fetch(action_id,
+                                      timeout=7200,
+                                      raise_on_timeout=True,
+                                      full_output=True)
+        self.assertEqual(outcome['status'], 'completed')
+        action_id = self.etcd[0].run_action('restore')
+        outcome = self.d.action_fetch(action_id,
+                                      timeout=7200,
+                                      raise_on_timeout=True,
+                                      full_output=True)
+        self.assertEqual(outcome['status'], 'completed')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Should fix: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/285

Etcd2 uses /var/snap/etcd/current/<app><unit>.etcd/ while etcd3 uses /var/snap/etcd/current/. Not sure what the motivation behind this change is. 