### PR TITLE
Add cdk-service-kicker to etcd charm

### DIFF
--- a/templates/cdk-service-kicker
+++ b/templates/cdk-service-kicker
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+# This service runs for a few minutes and restarts any failing CDK services
+# it sees during that time.
+#
+# This is a hacky workaround for this bug:
+# https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/357
+
+services="{{services}}"
+
+deadline="$(expr "$(date +%s)" + 600)"
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  for service in $services; do
+    echo "$service: checking"
+    if ! systemctl is-active "$service"; then
+      echo "$service: not active, restarting"
+      systemctl restart "$service" || true
+    fi
+  done
+
+  sleep 10
+done
+
+echo "deadline has passed, exiting gracefully"

--- a/templates/cdk-service-kicker.service
+++ b/templates/cdk-service-kicker.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=cdk-service-kicker
+
+[Service]
+ExecStart=/usr/bin/cdk-service-kicker
+Restart=on-failure
+Type=simple
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/357 for the etcd charm. So hacky.

I've lightly tested this. With this change, the etcd service now reliably comes up after rebooting the LXD host.