### PR TITLE
Minor lint fix. Blocking bundletester.

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -635,5 +635,5 @@ def etcd_version():
                 version = version.split('version')[-1].replace(':', '').strip()
                 return version
         return 'n/a'
-    except:
+    except: # NOQA
         return 'n/a'


### PR DESCRIPTION
Bundletester is failing with the following lint error: 

```
DEBUG:runner:call ['/usr/bin/make', '-s', 'lint'] (cwd: /tmp/bundletester-6l4B5P/etcd)
DEBUG:runner:py34 create: /tmp/bundletester-6l4B5P/etcd/.tox/py34
DEBUG:runner:ERROR: InterpreterNotFound: python3.4
DEBUG:runner:py35 create: /tmp/bundletester-6l4B5P/etcd/.tox/py35
DEBUG:runner:py35 installdeps: charmhelpers, charms.reactive, flake8, mock, pytest-cov, pytest
DEBUG:runner:py35 installed: charmhelpers==0.18.2,charms.reactive==0.5.0,coverage==4.4.1,flake8==3.5.0,Jinja2==2.9.6,MarkupSafe==1.0,mccabe==0.6.1,mock==2.0.0,netaddr==0.7.19,pbr==3.1.1,pkg-resources==0.0.0,py==1.4.34,pyaml==17.10.0,pycodestyle==2.3.1,pyflakes==1.6.0,pytest==3.2.3,pytest-cov==2.5.1,PyYAML==3.12,six==1.11.0,Tempita==0.5.2
DEBUG:runner:___________________________________ summary ____________________________________
DEBUG:runner:SKIPPED:  py34: InterpreterNotFound: python3.4
DEBUG:runner:  py35: skipped tests
DEBUG:runner:  congratulations :)
DEBUG:runner:reactive/etcd.py:638:5: E722 do not use bare except'
DEBUG:runner:Makefile:11: recipe for target 'lint' failed
DEBUG:runner:make: *** [lint] Error 1
DEBUG:runner:Exit Code: 2
```