### PR TITLE
Load etcd env variables from bash_aliases

### DIFF
--- a/actions/health
+++ b/actions/health
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+source ~/.bash_aliases
 OUT=$(/snap/bin/etcd.etcdctl -C http://127.0.0.1:4001 cluster-health)
 
 action-set result-map.message="${OUT}"

--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -2,12 +2,12 @@
 
 # The certificates live in leader-data. Grab them from there, always
 
+source ~/.bash_aliases
 mkdir -p etcd_credentials
 
-# TODO: Update these with values grabbed from layer.yaml
-cp /var/snap/etcd/common/client.crt etcd_credentials/client.crt
-cp /var/snap/etcd/common/client.key etcd_credentials/client.key
-cp /var/snap/etcd/common/ca.crt etcd_credentials/ca.crt
+cp $ETCDCTL_CERT_FILE etcd_credentials/client.crt
+cp $ETCDCTL_KEY_FILE etcd_credentials/client.key
+cp $ETCDCTL_CA_FILE etcd_credentials/ca.crt
 
 # Render a README heredoc
 cat << EOF > etcd_credentials/README.txt


### PR DESCRIPTION
health action is failing and package-client-credentials is grabbing certificates from a hard coded path.

With this patch we grab etcd certificate related env variables from bash_aliases  that holds what we use in layers.yaml options (https://github.com/juju-solutions/layer-etcd/blob/master/reactive/etcd.py#L406)