### PR TITLE
Work on snapshot and restore of etcd

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -19,6 +19,10 @@ snapshot:
       type: string
       default: '/home/ubuntu/etcd-snapshots'
       description: Location to save the etcd snapshot.
+    keys-version:
+      type: string
+      default: 'v2'
+      description: Version of keys to snapshoot. Allowed values 'v3' or 'v2'.
 restore:
   description: Restore an etcd cluster's data from a snapshot tarball.
   params:

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -11,6 +11,7 @@ set -ex
 # prevent the new node from inadvertently being joined onto an existing cluster.
 
 ETCD_BACKUP_TARGET_DIR=$(action-get target)
+ETCD_KEYS_VERSION=$(action-get keys-version)
 #ETCD_DATA_DIR=/var/lib/etcd/default
 UNIT_NAME=${JUJU_UNIT_NAME%%/*}
 UNIT_NUM=${JUJU_UNIT_NAME#*/}
@@ -25,8 +26,16 @@ ARCHIVE=etcd-snapshot-$DATE_STAMP.tar.gz
 # Ensure the backupd target exists
 mkdir -p $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_ID
 
-# Dump the data currently in the cluster
-/snap/bin/etcd.etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+if [ "${ETCD_KEYS_VERSION}" == "v2" ]; then
+  # Dump the data currently in the cluster
+  /snap/bin/etcd.etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+elif [ "${ETCD_KEYS_VERSION}" == "v3" ]; then
+  mkdir -p $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+  cp /var/snap/etcd/current/member/snap/db $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+else
+  action-fail "keys-version must be either v2 or v3"
+  exit
+fi
 
 # Create the backup archive
 cd $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -31,7 +31,7 @@ if [ "${ETCD_KEYS_VERSION}" == "v2" ]; then
   /snap/bin/etcd.etcdctl backup --data-dir $ETCD_DATA_DIR --backup-dir $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
 elif [ "${ETCD_KEYS_VERSION}" == "v3" ]; then
   mkdir -p $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
-  cp /var/snap/etcd/current/member/snap/db $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
+  cp $ETCD_DATA_DIR/member/snap/db $ETCD_BACKUP_TARGET_DIR/$JUJU_ACTION_UUID
 else
   action-fail "keys-version must be either v2 or v3"
   exit

--- a/tests/20-actions.py
+++ b/tests/20-actions.py
@@ -4,6 +4,7 @@ import os
 import re
 import unittest
 import subprocess
+import time
 
 import amulet
 
@@ -22,20 +23,46 @@ class TestActions(unittest.TestCase):
         # cls.d.sentry.wait()
         cls.etcd = cls.d.sentry['etcd']
 
-    def test_snapshot_restore(self):
+    def test_health_check(self):
         """
-        Trigger snapshot and restore actions
+        Trigger health action
         """
-        action_id = self.etcd[0].run_action('snapshot')
+        action_id = self.etcd[0].run_action('health')
         outcome = self.d.action_fetch(action_id,
                                       timeout=7200,
                                       raise_on_timeout=True,
                                       full_output=True)
         self.assertEqual(outcome['status'], 'completed')
-        cpcmd = outcome['results']['copy']['cmd']
-        subprocess.check_call(cpcmd.split())
-        filename = os.path.basename(outcome['results']['snapshot']['path'])
-        cmd = 'juju attach etcd snapshot=%s' % filename
+        self.assertTrue("cluster is healthy" in outcome['results']['result-map']['message'])
+
+    def test_snapshot_restore(self):
+        """
+        Trigger snapshot and restore actions
+        """
+        # Load dummy data
+        self.load_data()
+        self.assertTrue(self.is_data_present('v2'))
+        self.assertTrue(self.is_data_present('v3'))
+
+        filenames = {}
+        for dataset in ['v2', 'v3']:
+            # Take snapshot of data
+            action_id = self.etcd[0].run_action('snapshot', {'keys-version':dataset})
+            outcome = self.d.action_fetch(action_id,
+                                          timeout=7200,
+                                          raise_on_timeout=True,
+                                          full_output=True)
+            self.assertEqual(outcome['status'], 'completed')
+            cpcmd = outcome['results']['copy']['cmd']
+            subprocess.check_call(cpcmd.split())
+            filenames[dataset] = os.path.basename(outcome['results']['snapshot']['path'])
+
+        self.delete_data()
+        self.assertFalse(self.is_data_present('v2'))
+        self.assertFalse(self.is_data_present('v3'))
+
+        # Restore v2 data
+        cmd = 'juju attach etcd snapshot=%s' % filenames['v2']
         subprocess.check_call(cmd.split())
         action_id = self.etcd[0].run_action('restore')
         outcome = self.d.action_fetch(action_id,
@@ -43,6 +70,74 @@ class TestActions(unittest.TestCase):
                                       raise_on_timeout=True,
                                       full_output=True)
         self.assertEqual(outcome['status'], 'completed')
+        self.assertTrue(self.is_data_present('v2'))
+        self.assertFalse(self.is_data_present('v3'))
+
+        # Restore v3 data
+        cmd = 'juju attach etcd snapshot=%s' % filenames['v3']
+        subprocess.check_call(cmd.split())
+        action_id = self.etcd[0].run_action('restore')
+        outcome = self.d.action_fetch(action_id,
+                                      timeout=7200,
+                                      raise_on_timeout=True,
+                                      full_output=True)
+        self.assertEqual(outcome['status'], 'completed')
+        self.assertFalse(self.is_data_present('v2'))
+        self.assertTrue(self.is_data_present('v3'))
+
+    def load_data(self):
+        """
+        Load dummy data
+
+        """
+        certs = "ETCDCTL_KEY_FILE=/var/snap/etcd/common/client.key " \
+                "ETCDCTL_CERT_FILE=/var/snap/etcd/common/client.crt " \
+                "ETCDCTL_CA_FILE=/var/snap/etcd/common/ca.crt"
+
+        cmd = '{} ETCDCTL_API=2 /snap/bin/etcdctl set /etcd2key etcd2value'.format(certs)
+        self.etcd[0].run(cmd)
+        cmd = '{} ETCDCTL_API=3 /snap/bin/etcdctl --endpoints=http://localhost:4001 ' \
+              'put etcd3key etcd3value'.format(certs)
+        self.etcd[0].run(cmd)
+
+    def is_data_present(self, version):
+        '''
+        Check if we have the data present on the datastore of the version
+        Args:
+            version: v2 or v3 etcd datastore
+
+        Returns: True if the data is present
+
+        '''
+        certs = "ETCDCTL_KEY_FILE=/var/snap/etcd/common/client.key " \
+                "ETCDCTL_CERT_FILE=/var/snap/etcd/common/client.crt " \
+                "ETCDCTL_CA_FILE=/var/snap/etcd/common/ca.crt"
+
+        if version == 'v2':
+            cmd = '{} ETCDCTL_API=2 /snap/bin/etcdctl ls'.format(certs)
+            data = self.etcd[0].run(cmd)
+            return 'etcd2key' in data[0]
+        elif version == 'v3':
+            cmd = '{} ETCDCTL_API=3 /snap/bin/etcdctl --endpoints=http://localhost:4001 ' \
+                  'get "" --prefix --keys-only'.format(certs)
+            data = self.etcd[0].run(cmd)
+            return 'etcd3key' in data[0]
+        else:
+            return False
+
+    def delete_data(self):
+        '''
+        Delete all dummy data on etcd
+        '''
+        certs = "ETCDCTL_KEY_FILE=/var/snap/etcd/common/client.key " \
+                "ETCDCTL_CERT_FILE=/var/snap/etcd/common/client.crt " \
+                "ETCDCTL_CA_FILE=/var/snap/etcd/common/ca.crt"
+
+        cmd = '{} ETCDCTL_API=2 /snap/bin/etcdctl rm /etcd2key'.format(certs)
+        self.etcd[0].run(cmd)
+        cmd = '{} ETCDCTL_API=3 /snap/bin/etcdctl --endpoints=http://localhost:4001 ' \
+              'del etcd3key'.format(certs)
+        self.etcd[0].run(cmd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The snapshot action by default snapshots v2 data (for backwards compatibility). If you want v3 data to be backed up we need to set keys-version to v3. This gives us backwards compatibility but might not be convenient in the future.