### PR TITLE
Add network spaces support

### DIFF
--- a/actions/restore.py
+++ b/actions/restore.py
@@ -6,11 +6,11 @@ from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import log
-from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import resource_get
 from charmhelpers.core.host import chdir
 from charmhelpers.core.host import service_start
 from charmhelpers.core.host import service_stop
+from etcd_lib import get_ingress_address
 from shlex import split
 from subprocess import check_call
 from subprocess import check_output
@@ -33,7 +33,7 @@ if not os.path.isdir(ETCD_DATA_DIR):
     ETCD_DATA_DIR = opts['etcd_data_dir']
 
 ETCD_PORT = config('management_port')
-PRIVATE_ADDRESS = unit_get('private-address')
+CLUSTER_ADDRESS = get_ingress_address('cluster')
 SKIP_BACKUP = action_get('skip-backup')
 SNAPSHOT_ARCHIVE = resource_get('snapshot')
 TARGET_PATH = action_get('target')
@@ -117,7 +117,7 @@ def reconfigure_client_advertise():
     member_id = members.split(b':')[0].decode('utf-8')
 
     raw_update = "/snap/bin/etcd.etcdctl member update {0} http://{1}:{2}"
-    update_cmd = raw_update.format(member_id, PRIVATE_ADDRESS, ETCD_PORT)
+    update_cmd = raw_update.format(member_id, CLUSTER_ADDRESS, ETCD_PORT)
     check_call(split(update_cmd))
 
 

--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -5,6 +5,7 @@ from charmhelpers.core.hookenv import is_leader
 from charmhelpers.core.hookenv import leader_get
 from charmhelpers.core import unitdata
 from charms.reactive import is_state
+from etcd_lib import get_ingress_address
 
 import string
 import random
@@ -18,7 +19,8 @@ class EtcdDatabag:
     when expanded looks like the following:
 
     {'public_address': '127.0.0.1',
-     'private_address': '127.0.0.1',
+     'cluster_address': '127.0.0.1',
+     'db_address': '127.0.0.1',
      'unit_name': 'etcd0',
      'port': '2380',
      'management_port': '2379',
@@ -35,7 +37,8 @@ class EtcdDatabag:
         self.management_port = config('management_port')
         # Live polled properties
         self.public_address = unit_get('public-address')
-        self.private_address = unit_get('private-address')
+        self.cluster_address = get_ingress_address('cluster')
+        self.db_address = get_ingress_address('db')
         self.unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '')
 
         # Pull the TLS certificate paths from layer data

--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -1,0 +1,15 @@
+from charmhelpers.core.hookenv import network_get, unit_private_ip
+
+
+def get_ingress_address(endpoint_name):
+    ''' Returns ingress-address belonging to the named endpoint, if available.
+    Falls back to private-address if necessary. '''
+    try:
+        data = network_get(endpoint_name)
+    except NotImplementedError:
+        return unit_private_ip()
+
+    if 'ingress-addresses' in data:
+        return data['ingress-addresses'][0]
+    else:
+        return unit_private_ip()

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -23,11 +23,11 @@ class EtcdCtl:
 
         @params cluster_data - a dict of data to fill out the request to
         push our registration to the leader
-        requires keys: leader_address, port, unit_name, private_address,
+        requires keys: leader_address, port, unit_name, cluster_address,
         management_port
         '''
         # Build a connection string for the cluster data.
-        connection = get_connection_string([cluster_data['private_address']],
+        connection = get_connection_string([cluster_data['cluster_address']],
                                            cluster_data['management_port'])
         # Create a https url to the leader unit name on the private addres.
         command = "{3} -C {0} member add {1} " \

--- a/templates/etcd2.conf
+++ b/templates/etcd2.conf
@@ -1,10 +1,10 @@
 # This file is rendered by Juju, manual edits will not be persisted
 ETCD_DATA_DIR={{ etcd_data_dir }}/{{ unit_name }}.etcd
 ETCD_NAME={{ unit_name }}
-ETCD_ADVERTISE_CLIENT_URLS="https://{{ private_address }}:{{ port }}"
+ETCD_ADVERTISE_CLIENT_URLS="https://{{ db_address }}:{{ port }}"
 ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://0.0.0.0:{{ port }}"
 ETCD_LISTEN_PEER_URLS="https://0.0.0.0:{{ management_port }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ private_address }}:{{ management_port }}"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ cluster_address }}:{{ management_port }}"
 {% if cluster %}
 ETCD_INITIAL_CLUSTER="{{ cluster }}"
 ETCD_INITIAL_CLUSTER_STATE={{ cluster_state }}

--- a/templates/etcd3.conf
+++ b/templates/etcd3.conf
@@ -39,11 +39,11 @@ cors:
 
 # List of this member's peer URLs to advertise to the rest of the cluster.
 # The URLs needed to be a comma-separated list.
-initial-advertise-peer-urls: https://{{ private_address }}:{{ management_port }}
+initial-advertise-peer-urls: https://{{ cluster_address }}:{{ management_port }}
 
 # List of this member's client URLs to advertise to the public.
 # The URLs needed to be a comma-separated list.
-advertise-client-urls: https://{{ private_address }}:{{ port }}
+advertise-client-urls: https://{{ db_address }}:{{ port }}
 
 # Discovery URL used to bootstrap the cluster.
 discovery: 

--- a/unit_tests/test_etcdctl.py
+++ b/unit_tests/test_etcdctl.py
@@ -12,7 +12,7 @@ class TestEtcdCtl:
 
     def test_register(self):
         with patch('etcdctl.check_output') as spcm:
-            self.etcdctl().register({'private_address': '127.0.0.1',
+            self.etcdctl().register({'cluster_address': '127.0.0.1',
                                      'unit_name': 'etcd0',
                                      'management_port': '1313',
                                      'leader_address': 'http://127.1.1.1:1212'})  # noqa


### PR DESCRIPTION
This adds network spaces support to etcd:
* For etcd <-> etcd communication, use `cluster` endpoint's ingress-address instead of private-address
* For etcd <-> client communication, use `db` endpoint's ingress-address instead of private-address
* Add both ingress addresses to certificate SAN list

This should be reviewed and merged together with https://github.com/juju-solutions/interface-etcd/pull/10