### PR TITLE
Don't set etcd.registered if registration failed

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -330,6 +330,11 @@ def register_node_with_leader(cluster):
 
             bag.cluster_unit_id = resp['cluster_unit_id']
             bag.cluster = resp['cluster']
+        else:
+            log('etcdctl.register failed, will retry')
+            msg = 'Waiting to retry etcd registration'
+            status_set('waiting', msg)
+            return
 
     render_config(bag)
     host.service_restart(bag.etcd_daemon)


### PR DESCRIPTION
This fixes a rare deployment problem where one of the units comes up in an "Errored with 0 known peers" state.

The problem occurs when a follower unit's call to `etcdctl register` occurs at the same as a service restart of snap.etcd.etcd on the leader unit. Registration fails, but the unit continues on as if it succeeded, setting `etcd.registered` and never trying again.

The fix is to catch the failure and bail out before setting `etcd.registered` so a retry will occur.