### PR TITLE
Revert "Switch to etcd snap to 3.2"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,5 +9,5 @@ options:
     description: Port to run the ETCD Management service
   channel:
     type: string
-    default: 3.2/stable
+    default: 2.3/stable
     description: The snap channel to install from


### PR DESCRIPTION
Reverts juju-solutions/layer-etcd#115

Occasionally seeing etcd broken after a charm upgrade to edge:
```
etcd/0*                   active    idle   1        18.233.158.232  2379/tcp  Errored with 0 known peers
etcd/1                    active    idle   2        54.242.230.117  2379/tcp  Errored with 0 known peers
etcd/2                    active    idle   3        52.54.208.170   2379/tcp  Errored with 0 known peers
```

This is happening because etcd is automatically and incorrectly upgraded to v3.2.

etcd is in a crash loop, logging this:
```
panic: recovering backend from snapshot error: database snapshot file path error: snap: snapshot file doesn't exist
```

This doc indicates that you should upgrade to 3.0 first, and not upgrade to 3.2 until you have v3 data: https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_0.md

> NOTE: When migrating from v2 with no v3 data, etcd server v3.2+ panics when etcd restores from existing snapshots but no v3 ETCD_DATA_DIR/member/snap/db file. This happens when the server had migrated from v2 with no previous v3 data. This also prevents accidental v3 data loss (e.g. db file might have been moved). etcd requires that post v3 migration can only happen with v3 data. Do not upgrade to newer v3 versions until v3.0 server contains v3 data.

This issue indicates the same: https://github.com/coreos/etcd/issues/9480

We need to revert back to 2.3 as the default so that charm upgrades don't result in a broken cluster. We will have to come up with a new way to make 3.2 the default on new deployments without breaking upgrades.