### PR TITLE
Adding tox as a dependency of tests

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -4,3 +4,4 @@ makefile:
   - lint
 packages:
   - amulet
+  - tox


### PR DESCRIPTION
Bundletester is failing with 
```
DEBUG:runner:call ['/usr/bin/make', '-s', 'lint'] (cwd: /tmp/bundletester-kGa8by/etcd)
DEBUG:runner:make: tox: Command not found
DEBUG:runner:Makefile:11: recipe for target 'lint' failed
DEBUG:runner:make: *** [lint] Error 127
DEBUG:runner:Exit Code: 2
```

This just adds tox to the dependencies list.