### PR TITLE
support new snapd_refresh from layer-snap

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,12 @@ options:
     type: string
     default: 2.3/stable
     description: The snap channel to install from
+  snapd_refresh:
+    default: "max"
+    type: string
+    description: |
+      How often snapd handles updates for installed snaps. The default
+      (an empty string) is 4x per day. Set to "max" to check once per month
+      based on the charm deployment date. You may also set a custom string as
+      described in the 'refresh.timer' section here:
+        https://forum.snapcraft.io/t/system-options/87

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -420,20 +420,18 @@ def initialize_new_leader():
 def process_snapd_timer():
     ''' Set the snapd refresh timer on the leader so all cluster members
     (present and future) will refresh near the same time. '''
-    # Get the current snapd refresh timer (layer-snap will set this). Note
-    # we can't use snap.get because layer-snap doesn't set snap.installed.core.
-    cmd = ['snap', 'get', 'core', 'refresh.timer']
+    # Get the current snapd refresh timer (layer-snap will set this).
     try:
-        system_timer = check_output(cmd).decode('utf-8')
+        timer = snap.get(snapname='core', key='refresh.timer').decode('utf-8')
     except CalledProcessError:
         log('snapd_refresh timer not yet set, will retry')
         return
 
     # The first time through, data_changed will be true. Subsequent calls
     # should only update leader data if something changed.
-    if data_changed('etcd_snapd_refresh', system_timer):
-        log('setting snapd_refresh timer to: {}'.format(system_timer))
-        leader_set({'snapd_refresh': system_timer})
+    if data_changed('etcd_snapd_refresh', timer):
+        log('setting snapd_refresh timer to: {}'.format(timer))
+        leader_set({'snapd_refresh': timer})
 
 
 @when('snap.installed.etcd')

--- a/tests/10-deploy.py
+++ b/tests/10-deploy.py
@@ -30,6 +30,18 @@ class TestDeployment(unittest.TestCase):
         self.assertFalse("inactive" in status[0])
         self.assertTrue("active" in status[0])
 
+    def test_config_snapd_refresh(self):
+        ''' Verify initial snap refresh config is set and can be changed '''
+        # default timer should be some day of the week followed by a number
+        timer = self.leader.run('snap get core refresh.timer')
+        self.assertTrue(len(timer[0]) == len('dayX'))
+
+        # verify a new timer value
+        self.d.configure('etcd', {'snapd_refresh': 'fri5'})
+        self.d.sentry.wait()
+        timer = self.leader.run('snap get core refresh.timer')
+        self.assertTrue(timer[0] == 'fri5')
+
     def test_node_scale(self):
         ''' Scale beyond 1 node because etcd supports peering as a standalone
         application.'''

--- a/tests/20-actions.py
+++ b/tests/20-actions.py
@@ -4,7 +4,6 @@ import os
 import re
 import unittest
 import subprocess
-import time
 
 import amulet
 
@@ -47,7 +46,7 @@ class TestActions(unittest.TestCase):
         filenames = {}
         for dataset in ['v2', 'v3']:
             # Take snapshot of data
-            action_id = self.etcd[0].run_action('snapshot', {'keys-version':dataset})
+            action_id = self.etcd[0].run_action('snapshot', {'keys-version': dataset})
             outcome = self.d.action_fetch(action_id,
                                           timeout=7200,
                                           raise_on_timeout=True,


### PR DESCRIPTION
Default our etcd charm to use the 'max' possible refresh window,
which is currently to refresh once a month. The leader will get
the initial value and set leader data so all followers (present
and future) will refresh around the same time.

Adding an amulet test for this and fixed up lint issues in the tests.