### PR TITLE
Fix rejected connections due to IP missing from SANs

### DIFF
--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -1,15 +1,21 @@
 from charmhelpers.core.hookenv import network_get, unit_private_ip
 
 
-def get_ingress_address(endpoint_name):
-    ''' Returns ingress-address belonging to the named endpoint, if available.
-    Falls back to private-address if necessary. '''
+def get_ingress_addresses(endpoint_name):
+    ''' Returns all ingress-addresses belonging to the named endpoint, if
+    available. Falls back to private-address if necessary. '''
     try:
         data = network_get(endpoint_name)
     except NotImplementedError:
-        return unit_private_ip()
+        return [unit_private_ip()]
 
     if 'ingress-addresses' in data:
-        return data['ingress-addresses'][0]
+        return data['ingress-addresses']
     else:
-        return unit_private_ip()
+        return [unit_private_ip()]
+
+
+def get_ingress_address(endpoint_name):
+    ''' Returns an ingress-address belonging to the named endpoint, if
+    available. Falls back to private-address if necessary. '''
+    return get_ingress_addresses(endpoint_name)[0]

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -29,7 +29,7 @@ from charmhelpers.contrib.charmsupport import nrpe
 from etcdctl import EtcdCtl
 from etcdctl import get_connection_string
 from etcd_databag import EtcdDatabag
-from etcd_lib import get_ingress_address
+from etcd_lib import get_ingress_address, get_ingress_addresses
 
 from shlex import split
 from subprocess import check_call
@@ -107,8 +107,8 @@ def prepare_tls_certificates(tls):
     common_name = hookenv.unit_public_ip()
     sans = set()
     sans.add(hookenv.unit_public_ip())
-    sans.add(get_ingress_address('db'))
-    sans.add(get_ingress_address('cluster'))
+    sans.update(get_ingress_addresses('db'))
+    sans.update(get_ingress_addresses('cluster'))
     sans.add(socket.gethostname())
     sans = list(sans)
     certificate_name = hookenv.local_unit().replace('/', '_')


### PR DESCRIPTION
This PR makes it so that all ingress addresses are added to the TLS certificate's SANs, not just the one ingress address that is advertised to peers.

This should hopefully fix https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/610.

@ktsakalozos 