### PR TITLE
remove path.py from wheelhouse

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,1 @@
-path.py>=8.0.0,<=9.0.0
 charms.templating.jinja2>=1.0.0,<2.0.0


### PR DESCRIPTION
As noted in #131, I do not think we use path.py anymore. It came in
2+ years ago here:

https://github.com/juju-solutions/layer-etcd/commit/b07a222fe9c00fd13c0440d1b49ca7ea1143da3e#diff-52f13f84394364d44bc7a2fed930e09dR18

The only ref I can find to `import path` was removed a few months
later when the install source code was yanked:

https://github.com/juju-solutions/layer-etcd/commit/dc0f31e5cd798e1a3bd1065e943b6c45f217b151#diff-52f13f84394364d44bc7a2fed930e09dL21