### PR TITLE
Allow setting specific address where for service to bind to

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,3 +20,11 @@ options:
       based on the charm deployment date. You may also set a custom string as
       described in the 'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
+  service_network_interface:
+    type: string
+    default: ""
+    description: |
+      The interface the service binds to. Valid values are 'public' or 'private'
+      to bind to public or private unit address respectively.
+      If an empty or an invalid value is set, the service binds to all network
+      interfaces.

--- a/config.yaml
+++ b/config.yaml
@@ -20,11 +20,9 @@ options:
       based on the charm deployment date. You may also set a custom string as
       described in the 'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
-  service_network_interface:
-    type: string
-    default: ""
+  bind_to_all_interfaces:
+    type: boolean
+    default: true
     description: |
-      The interface the service binds to. Valid values are 'public' or 'private'
-      to bind to public or private unit address respectively.
-      If an empty or an invalid value is set, the service binds to all network
-      interfaces.
+      The service binds to all network interfaces if true. The service binds
+      only to the first found bind address of each relation if false

--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -19,3 +19,50 @@ def get_ingress_address(endpoint_name):
     ''' Returns an ingress-address belonging to the named endpoint, if
     available. Falls back to private-address if necessary. '''
     return get_ingress_addresses(endpoint_name)[0]
+
+
+def get_bind_address(endpoint_name):
+    ''' Returns the first bind-address found in network info
+    belonging to the named endpoint, if available.
+    Falls back to private-address if necessary.
+
+        @param endpoint_name the endpoint from where taking the
+        bind address
+    '''
+    try:
+        data = network_get(endpoint_name)
+    except NotImplementedError:
+        return unit_private_ip()
+
+    # Consider that network-get returns something like:
+    #
+    # bind-addresses:
+    # - macaddress: 02:d0:9e:31:d9:e0
+    # interfacename: ens5
+    # addresses:
+    # - hostname: ""
+    #     address: 172.31.5.4
+    #     cidr: 172.31.0.0/20
+    # - hostname: ""
+    #     address: 172.31.5.4
+    #     cidr: 172.31.0.0/20
+    # - macaddress: 8a:32:d7:8d:f6:9a
+    # interfacename: fan-252
+    # addresses:
+    # - hostname: ""
+    #     address: 252.5.4.1
+    #     cidr: 252.0.0.0/12
+    # egress-subnets:
+    # - 172.31.5.4/32
+    # ingress-addresses:
+    # - 172.31.5.4
+    # - 172.31.5.4
+    # - 252.5.4.1
+    if 'bind-addresses' in data:
+        bind_addresses = data['bind-addresses']
+        if len(bind_addresses) > 0:
+            if 'addresses' in bind_addresses[0]:
+                if len(bind_addresses[0]['addresses']) > 0:
+                    return bind_addresses[0]['addresses'][0]['address']
+
+    return unit_private_ip()

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -177,6 +177,17 @@ def follower_config_changed():
     close_open_ports()
 
 
+@when('snap.installed.etcd')
+@when('config.changed.service_network_interface')
+@when_not('etcd.installed')
+def service_network_interface_changed():
+    ''' Config must be updated and service restarted '''
+    bag = EtcdDatabag()
+    log('Rendering config file for {0}'.format(bag.unit_name))
+    render_config()
+    host.service_restart(bag.etcd_daemon)
+
+
 @when('cluster.joined')
 def set_db_ingress_address(cluster):
     ''' Send db ingress address to peers on the cluster relation '''

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -178,9 +178,8 @@ def follower_config_changed():
 
 
 @when('snap.installed.etcd')
-@when('config.changed.service_network_interface')
-@when_not('etcd.installed')
-def service_network_interface_changed():
+@when('config.changed.bind_to_all_interfaces')
+def bind_to_all_interfaces_changed():
     ''' Config must be updated and service restarted '''
     bag = EtcdDatabag()
     log('Rendering config file for {0}'.format(bag.unit_name))

--- a/templates/etcd2.conf
+++ b/templates/etcd2.conf
@@ -2,8 +2,8 @@
 ETCD_DATA_DIR={{ etcd_data_dir }}/{{ unit_name }}.etcd
 ETCD_NAME={{ unit_name }}
 ETCD_ADVERTISE_CLIENT_URLS="https://{{ db_address }}:{{ port }}"
-ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://0.0.0.0:{{ port }}"
-ETCD_LISTEN_PEER_URLS="https://0.0.0.0:{{ management_port }}"
+ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://{{ bind_address }}:{{ port }}"
+ETCD_LISTEN_PEER_URLS="https://{{ bind_address }}:{{ management_port }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ cluster_address }}:{{ management_port }}"
 {% if cluster %}
 ETCD_INITIAL_CLUSTER="{{ cluster }}"

--- a/templates/etcd2.conf
+++ b/templates/etcd2.conf
@@ -2,8 +2,8 @@
 ETCD_DATA_DIR={{ etcd_data_dir }}/{{ unit_name }}.etcd
 ETCD_NAME={{ unit_name }}
 ETCD_ADVERTISE_CLIENT_URLS="https://{{ db_address }}:{{ port }}"
-ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://{{ bind_address }}:{{ port }}"
-ETCD_LISTEN_PEER_URLS="https://{{ bind_address }}:{{ management_port }}"
+ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://{{ db_bind_address }}:{{ port }}"
+ETCD_LISTEN_PEER_URLS="https://{{ cluster_bind_address }}:{{ management_port }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ cluster_address }}:{{ management_port }}"
 {% if cluster %}
 ETCD_INITIAL_CLUSTER="{{ cluster }}"

--- a/templates/etcd3.conf
+++ b/templates/etcd3.conf
@@ -24,9 +24,9 @@ election-timeout: 1000
 quota-backend-bytes: 0
 
 # List of comma separated URLs to listen on for peer traffic.
-listen-peer-urls: https://0.0.0.0:{{ management_port}}
+listen-peer-urls: https://{{ bind_address }}:{{ management_port}}
 # List of comma separated URLs to listen on for client traffic.
-listen-client-urls: http://127.0.0.1:4001,https://0.0.0.0:{{ port }}
+listen-client-urls: http://127.0.0.1:4001,https://{{ bind_address }}:{{ port }}
 
 # Maximum number of snapshot files to retain (0 is unlimited).
 max-snapshots: 5

--- a/templates/etcd3.conf
+++ b/templates/etcd3.conf
@@ -24,9 +24,9 @@ election-timeout: 1000
 quota-backend-bytes: 0
 
 # List of comma separated URLs to listen on for peer traffic.
-listen-peer-urls: https://{{ bind_address }}:{{ management_port}}
+listen-peer-urls: https://{{ cluster_bind_address }}:{{ management_port}}
 # List of comma separated URLs to listen on for client traffic.
-listen-client-urls: http://127.0.0.1:4001,https://{{ bind_address }}:{{ port }}
+listen-client-urls: http://127.0.0.1:4001,https://{{ db_bind_address }}:{{ port }}
 
 # Maximum number of snapshot files to retain (0 is unlimited).
 max-snapshots: 5


### PR DESCRIPTION
snap.etcd.etcd.service can now listen only in unit private or public address, or in any, as so far.

config: added service_network_interface parameter
reactive: react to service_network_interface config changed
templates.etcd2 and templates.etcd3: updated listening addresses