### PR TITLE
Etcd snap is not classic anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
  - sudo add-apt-repository -y ppa:juju/stable
  - sudo apt-get update
  - sudo apt-get install -y snapd charm-tools
- - sudo snap install charm
+ - sudo snap install charm --classic
 
 script:
  - mkdir -p $HOME/tmp/repo/layer

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -278,7 +278,7 @@ def send_cluster_details(proxy):
 @when_not('etcd.installed')
 def snap_install():
     channel = hookenv.config('channel')
-    snap.install('etcd', channel=channel, classic=True)
+    snap.install('etcd', channel=channel, classic=False)
 
 
 @when('etcd.ssl.placed')
@@ -297,7 +297,7 @@ def install_etcd():
 
     channel = hookenv.config('channel')
     # Grab the snap channel from config
-    snap.install('etcd', channel=channel, classic=True)
+    snap.install('etcd', channel=channel, classic=False)
 
 
 @when('snap.installed.etcd')


### PR DESCRIPTION
This is to fix https://bugs.launchpad.net/charm-etcd/+bug/1813678 .

Etcd installation is failing with the recent core.