### PR TITLE
Adding patch from cdk to fix snapd_refresh smash by subordinate charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,5 +370,7 @@ follow the migration instructions above in the restore action description.
 
 # Contact
 
-The `etcd` charm is free and open source software created by the
-~containers team at Canonical.
+The `etcd` charm is free and open source software maintained by the
+[Charmed Kubernetes][cdk-contact] team at Canonical.
+
+[cdk-contact]: https://www.ubuntu.com/kubernetes/docs/get-in-touch

--- a/config.yaml
+++ b/config.yaml
@@ -15,10 +15,10 @@ options:
     default: "max"
     type: string
     description: |
-      How often snapd handles updates for installed snaps. The default
-      (an empty string) is 4x per day. Set to "max" to check once per month
-      based on the charm deployment date. You may also set a custom string as
-      described in the 'refresh.timer' section here:
+      How often snapd handles updates for installed snaps. Set to an empty
+      string to check 4x per day. Set to "max" (the default) to check once per
+      month based on the charm deployment date. You may also set a custom
+      string as described in the 'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
   bind_to_all_interfaces:
     type: boolean

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -428,14 +428,12 @@ def process_snapd_timer():
     # Get the current snapd refresh timer; we know layer-snap has set this
     # when the 'snap.refresh.set' flag is present.
     timer = snap.get(snapname='core', key='refresh.timer').decode('utf-8').strip()
-    config_timer = hookenv.config('snapd_refresh')
-    if not timer and config_timer:
-        # The core snap timer is empty, yet we have a configured value. This
-        # likely means a subordinate timer reset ours. Try to set it back to
-        # a previously leader-set value, falling back to config if needed.
-        # Luckily, this should only happen once during subordinate install, so
-        # this should remain stable afterward.
-        timer = leader_get('snapd_refresh') or config_timer
+    if not timer:
+        # The core snap timer is empty. This likely means a subordinate timer
+        # reset ours. Try to set it back to a previously leader-set value,
+        # falling back to config if needed. Luckily, this should only happen
+        # during subordinate install, so this should remain stable afterward.
+        timer = leader_get('snapd_refresh') or hookenv.config('snapd_refresh')
         snap.set_refresh_timer(timer)
 
         # Ensure we have the timer known by snapd (it may differ from config).

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -428,6 +428,12 @@ def process_snapd_timer():
     # Get the current snapd refresh timer; we know layer-snap has set this
     # when the 'snap.refresh.set' flag is present.
     timer = snap.get(snapname='core', key='refresh.timer').decode('utf-8')
+    if not timer or timer.isspace():
+        # A subordinate wiped out our value, so we need to force it to be set
+        # again. Luckily, the subordinate should only wipe it out once, on
+        # first install, so this should remain stable afterward.
+        snap.set_refresh_timer(hookenv.config('snapd_refresh'))
+        timer = snap.get(snapname='core', key='refresh.timer').decode('utf-8')
 
     # The first time through, data_changed will be true. Subsequent calls
     # should only update leader data if something changed.

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -54,7 +54,7 @@ import traceback
 # Override the default nagios shortname regex to allow periods, which we
 # need because our bin names contain them (e.g. 'snap.foo.daemon'). The
 # default regex in charmhelpers doesn't allow periods, but nagios itself does.
-nrpe.Check.shortname_re = '[\.A-Za-z0-9-_]+$'
+nrpe.Check.shortname_re = r'[\.A-Za-z0-9-_]+$'
 
 
 @when('etcd.installed')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -456,7 +456,7 @@ def set_snapd_timer():
     # Layer-snap will always set a core refresh.timer, which may not be the
     # same as our leader. Gating with 'snap.refresh.set' ensures layer-snap
     # has finished and we are free to set our config to the leader's timer.
-    timer = leader_get('snapd_refresh')
+    timer = leader_get('snapd_refresh') or ''  # None will cause error
     log('setting snapd_refresh timer to: {}'.format(timer))
     snap.set_refresh_timer(timer)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 120
+
 [tox]
 skipsdist=True
 envlist = py34, py35


### PR DESCRIPTION
Also had to add a check for space only. I wonder if that needs to be ported to cdk. I'll check in the morning...

https://github.com/juju-solutions/kubernetes/pull/212