### PR TITLE
Making sure cert has proper IP as well as DNS

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -103,7 +103,6 @@ def missing_relation_notice():
 
 
 @when('certificates.available')
-@when_not('etcd.ssl.placed')
 def prepare_tls_certificates(tls):
     status_set('maintenance', 'Requesting tls certificates.')
     common_name = hookenv.unit_public_ip()

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -108,7 +108,7 @@ def prepare_tls_certificates(tls):
     status_set('maintenance', 'Requesting tls certificates.')
     common_name = hookenv.unit_public_ip()
     sans = set()
-    sans.add(hookenv.unit_public_ip())
+    sans.add(socket.gethostbyname(hookenv.unit_public_ip()))
     sans.update(get_ingress_addresses('db'))
     sans.update(get_ingress_addresses('cluster'))
     sans.add(socket.gethostname())

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -107,7 +107,7 @@ def prepare_tls_certificates(tls):
     status_set('maintenance', 'Requesting tls certificates.')
     common_name = hookenv.unit_public_ip()
     sans = set()
-    sans.add(socket.gethostbyname(hookenv.unit_public_ip()))
+    sans.add(hookenv.unit_public_ip())
     sans.update(get_ingress_addresses('db'))
     sans.update(get_ingress_addresses('cluster'))
     sans.add(socket.gethostname())


### PR DESCRIPTION
In case hookenv.unit_public_ip returns DNS,
TLS cert file has only DNS for servername.
IP is also needed for the other component such as kubernetes-master

Then kubernetes-master faces issue with that.
Because kubernetes-master has IP for it's --etcd-servers option.

There is socket.gethostname already later, I think that
making the result of unit_public_ip real IP makes sense.