### PR TITLE
Fix etcd charm stuck on "Requesting tls certificates"

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -104,7 +104,6 @@ def missing_relation_notice():
 
 @when('certificates.available')
 def prepare_tls_certificates(tls):
-    status_set('maintenance', 'Requesting tls certificates.')
     common_name = hookenv.unit_public_ip()
     sans = set()
     sans.add(hookenv.unit_public_ip())


### PR DESCRIPTION
This should fix the build failures. The charm is getting stuck in maintenance/idle status with the "Requesting tls certificates." message. This happens because prepare_tls_certificates was recently changed to run on every hook invocation, and its status message sometimes overrides the active/idle healthy status.

The fix is to remove the "Requesting tls certificates." status. Now that it happens on every hook invocation, it's no longer a meaningful status to set.