### PR TITLE
Add new actions: alarm-list, alarm-disarm, compact, defrag

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,29 @@
+alarm-disarm:
+  description: |
+    Disarm all alarms.
+alarm-list:
+  description: |
+    List all alarms.
+compact:
+  description: |
+    Compact etcd event history.
+  params:
+    revision:
+      type: string
+      default: ''
+      description: |
+        Revision to compact to. Leave blank to compact to the latest revision.
+    physical:
+      type: boolean
+      default: False
+      description: |
+        Setting to True will cause the compaction process to exit only after
+        all revisions have been physically removed from the database.
+defrag:
+  description: |
+    Defragment the storage of the local etcd member.
 health:
-    description: Call the health of the cluster
+  description: Report the health of the cluster.
 package-client-credentials:
     description: |
      Generate a tarball of the client certificates to connect to the cluster

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -1,0 +1,168 @@
+#!/usr/local/sbin/charm-env python3
+
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+from charms import layer
+
+from charmhelpers.core.hookenv import (
+    action_get,
+    action_set,
+    action_fail,
+    action_name
+)
+
+
+def action_fail_now(*args, **kw):
+    '''Call action_fail() and exit immediately.
+
+    '''
+    action_fail(*args, **kw)
+    sys.exit(0)
+
+
+def etcdctl_path():
+    '''Return path to etcdctl binary.
+
+    '''
+    if os.path.isfile('/snap/bin/etcd.etcdctl'):
+        return '/snap/bin/etcd.etcdctl'
+    return 'etcdctl'
+
+
+def etcdctl(cmd, etcdctl_api='3', endpoints=':4001', **kw):
+    '''Call etcdctl with ``cmd`` as the command-line args.
+
+    '''
+    opts = layer.options('tls-client')
+
+    env = os.environ.copy()
+    env['ETCDCTL_CA_FILE'] = opts['ca_certificate_path']
+    env['ETCDCTL_CERT_FILE'] = opts['server_certificate_path']
+    env['ETCDCTL_KEY_FILE'] = opts['server_key_path']
+    if etcdctl_api:
+        env['ETCDCTL_API'] = etcdctl_api
+
+    etcdctl_cmd = etcdctl_path()
+    if endpoints:
+        etcdctl_cmd += ' --endpoints={}'.format(endpoints)
+
+    args = shlex.split(etcdctl_cmd) + shlex.split(cmd)
+    return subprocess.check_output(
+        args, env=env, stderr=subprocess.STDOUT, **kw).decode("utf-8").strip()
+
+
+def etcdctl_version():
+    '''Return etcdctl version.
+
+    '''
+    output = etcdctl("--version", etcdctl_api=None, endpoints=None)
+    first_line = output.split('\n')[0]
+    version = first_line.split(' ')[-1]
+    return version.strip()
+
+
+def requires_etcd_version(version_regex, human_version=None):
+    '''Decorator that enforces a specific version of etcdctl be present.
+
+    The decorated function will only be executed if the required version
+    of etcdctl is present. Otherwise, action_fail() will be called and
+    the process will exit immediately.
+
+    '''
+    def wrap(f):
+        def wrapped_f(*args):
+            version = etcdctl_version()
+            if not re.match(version_regex, version):
+                required_version = human_version or version_regex
+                action_fail_now(
+                    'This action requires etcd version {}'.format(
+                        required_version))
+            f(*args)
+        return wrapped_f
+    return wrap
+
+
+requires_etcd_v2 = requires_etcd_version(r'2\..*', human_version='2.x')
+requires_etcd_v3 = requires_etcd_version(r'3\..*', human_version='3.x')
+
+
+@requires_etcd_v3
+def alarm_disarm():
+    '''Call `etcdctl alarm disarm`.
+
+    '''
+    try:
+        output = etcdctl('alarm disarm')
+        action_set(dict(output=output))
+    except subprocess.CalledProcessError as e:
+        action_fail_now(e.output)
+
+
+@requires_etcd_v3
+def alarm_list():
+    '''Call `etcdctl alarm list`.
+
+    '''
+    try:
+        output = etcdctl('alarm list')
+        action_set(dict(output=output))
+    except subprocess.CalledProcessError as e:
+        action_fail_now(e.output)
+
+
+@requires_etcd_v3
+def compact():
+    '''Call `etcdctl compact`.
+
+    '''
+    def get_latest_revision():
+        try:
+            output = etcdctl('endpoint status --write-out="json"')
+        except subprocess.CalledProcessError as e:
+            action_fail_now(
+                'Failed to determine latest revision for '
+                'compaction: {}'.format(e))
+
+        m = re.search(r'"revision":(\d*)', output)
+        if not m:
+            action_fail_now(
+                "Failed to get revision from 'endpoint status' "
+                "output: {}".format(output))
+        return m.group(1)
+
+    revision = action_get('revision') or get_latest_revision()
+    physical = 'true' if action_get('physical') else 'false'
+    command = 'compact {} --physical={}'.format(revision, physical)
+    try:
+        output = etcdctl(command)
+        action_set(dict(output=output))
+    except subprocess.CalledProcessError as e:
+        action_fail_now(e.output)
+
+
+@requires_etcd_v3
+def defrag():
+    '''Call `etcdctl defrag`.
+
+    '''
+    try:
+        output = etcdctl('defrag')
+        action_set(dict(output=output))
+    except subprocess.CalledProcessError as e:
+        action_fail_now(e.output)
+
+
+if __name__ == '__main__':
+    ACTIONS = {
+        'alarm-disarm': alarm_disarm,
+        'alarm-list': alarm_list,
+        'compact': compact,
+        'defrag': defrag,
+    }
+
+    action = action_name()
+    ACTIONS[action]()

--- a/actions/alarm-disarm
+++ b/actions/alarm-disarm
@@ -1,0 +1,1 @@
+actions.py

--- a/actions/alarm-list
+++ b/actions/alarm-list
@@ -1,0 +1,1 @@
+actions.py

--- a/actions/compact
+++ b/actions/compact
@@ -1,0 +1,1 @@
+actions.py

--- a/actions/defrag
+++ b/actions/defrag
@@ -1,0 +1,1 @@
+actions.py


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-etcd/+bug/1825988

Tested all new actions against both etcd2 and etcd3.

On etcd2, they all return something similar to this (note the message):
```
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 alarm-list --wait
unit-etcd-0:
  id: 514cc422-0e01-4048-8261-942f0f8f2d5a
  message: This action requires etcd version 3.x
  status: failed
  timing:
    completed: 2019-05-02 20:56:40 +0000 UTC
    enqueued: 2019-05-02 20:56:39 +0000 UTC
    started: 2019-05-02 20:56:39 +0000 UTC
  unit: etcd/0
```

On etcd3, first we run the db out of space to cause an alarm:
```
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 alarm-list --wait
unit-etcd-0:
  id: 6ab4e82b-64ba-428d-8ede-aad2a9dd47e8
  results:
    output: memberID:4925482879119250446 alarm:NOSPACE
  status: completed
  timing:
    completed: 2019-05-03 04:01:58 +0000 UTC
    enqueued: 2019-05-03 04:01:55 +0000 UTC
    started: 2019-05-03 04:01:58 +0000 UTC
  unit: etcd/0
```

Then we compact and defrag the db the reclaim space:
```
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 compact --wait
unit-etcd-0:
  id: 082844da-97fc-4dd0-8859-b127d8ea27bb
  results:
    output: compacted revision 1158209
  status: completed
  timing:
    completed: 2019-05-03 04:02:15 +0000 UTC
    enqueued: 2019-05-03 04:02:13 +0000 UTC
    started: 2019-05-03 04:02:14 +0000 UTC
  unit: etcd/0
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 defrag --wait
unit-etcd-0:
  id: 0301040e-c597-42e0-8f76-ba4874cfe267
  results:
    output: Finished defragmenting etcd member[:4001]
  status: completed
  timing:
    completed: 2019-05-03 04:02:25 +0000 UTC
    enqueued: 2019-05-03 04:02:24 +0000 UTC
    started: 2019-05-03 04:02:24 +0000 UTC
  unit: etcd/0
```

Then we disarm the alarm:
```
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 alarm-disarm --wait
unit-etcd-0:
  id: 7a9c535a-ffce-460c-8c6d-7cb4b8204a1c
  results:
    output: memberID:4925482879119250446 alarm:NOSPACE
  status: completed
  timing:
    completed: 2019-05-03 04:02:43 +0000 UTC
    enqueued: 2019-05-03 04:02:39 +0000 UTC
    started: 2019-05-03 04:02:43 +0000 UTC
  unit: etcd/0
```

Then we show that the alarm is gone:
```
tvansteenburgh@slipgate:~/src/charmed-kubernetes/layer-etcd$ juju run-action etcd/0 alarm-list --wait
unit-etcd-0:
  id: 62b145a1-7359-4e4d-822e-0ba98752a9d3
  results:
    output: ""
  status: completed
  timing:
    completed: 2019-05-03 04:02:55 +0000 UTC
    enqueued: 2019-05-03 04:02:52 +0000 UTC
    started: 2019-05-03 04:02:55 +0000 UTC
  unit: etcd/0
```

