### PR TITLE
Add extra SAN IP entries for each other etcd unit to fix LP:1832568

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -14,6 +14,7 @@ from charms.reactive.helpers import data_changed
 
 from charms.templating.jinja2 import render
 
+from charmhelpers.core import unitdata
 from charmhelpers.core.hookenv import log
 from charmhelpers.core.hookenv import leader_set
 from charmhelpers.core.hookenv import leader_get
@@ -56,6 +57,7 @@ import traceback
 # default regex in charmhelpers doesn't allow periods, but nagios itself does.
 nrpe.Check.shortname_re = r'[\.A-Za-z0-9-_]+$'
 
+kv = unitdata.kv()
 
 @when('etcd.installed')
 def snap_upgrade_notice():
@@ -103,6 +105,14 @@ def missing_relation_notice():
 
 
 @when('certificates.available')
+@when('cluster.joined')
+def refresh_certificates(cluster, tls):
+    extra_sans = cluster.get_db_ingress_addresses()
+    kv.set('extra-sans', extra_sans)
+    prepare_tls_certificates(tls)
+
+
+@when('certificates.available')
 def prepare_tls_certificates(tls):
     common_name = hookenv.unit_public_ip()
     sans = set()
@@ -110,6 +120,9 @@ def prepare_tls_certificates(tls):
     sans.update(get_ingress_addresses('db'))
     sans.update(get_ingress_addresses('cluster'))
     sans.add(socket.gethostname())
+    if kv.get('extra-sans'):
+        for ip in kv.get('extra-sans'):
+            sans.add(ip)
     sans = sorted(sans)
     certificate_name = hookenv.local_unit().replace('/', '_')
     tls.request_server_cert(common_name, sans, certificate_name)


### PR DESCRIPTION
Uses the cluster relation to grab the db ingress address and add those to the SAN certificate request to mitigate https://bugs.launchpad.net/charm-etcd/+bug/1832568