### PR TITLE
Handle updates to certs or CA info

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -487,6 +487,20 @@ def tls_state_control():
     set_state('etcd.ssl.placed')
 
 
+@when('etcd.ssl.placed')
+@when_any('tls_client.ca.written',
+          'tls_client.server.certificate.written',
+          'tls_client.client.certificate.written')
+def tls_update():
+    ''' Handle changes to the TLS data by ensuring that the service is
+        restarted.
+    '''
+    remove_state('etcd.ssl.placed')
+    remove_state('tls_client.ca.written')
+    remove_state('tls_client.server.certificate.written')
+    remove_state('tls_client.client.certificate.written')
+
+
 @when_not('etcd.pillowmints')
 def render_default_user_ssl_exports():
     ''' Add secure credentials to default user environment configs,

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -495,7 +495,14 @@ def tls_update():
     ''' Handle changes to the TLS data by ensuring that the service is
         restarted.
     '''
+    # ensure config is updated with new certs and service restarted
+    bag = EtcdDatabag()
+    render_config(bag)
+    host.service_restart(bag.etcd_daemon)
+
+    # ensure that certs are re-echoed to the db relations
     remove_state('etcd.ssl.placed')
+
     remove_state('tls_client.ca.written')
     remove_state('tls_client.server.certificate.written')
     remove_state('tls_client.client.certificate.written')


### PR DESCRIPTION
If the certificates or CA info is updated (re-issued, transferred to a different CA, etc), the charm needs to handle that by updating the files on disk (already done) and restarting the services (added here).