### PR TITLE
Fix etcd 2->3 upgrade issue and loss of initial-cluster-token

### DIFF
--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -2,7 +2,7 @@ from charms import layer
 from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import is_leader
-from charmhelpers.core.hookenv import leader_get
+from charmhelpers.core.hookenv import leader_get, leader_set
 from charmhelpers.core import unitdata
 from charms.reactive import is_state
 from etcd_lib import get_ingress_address
@@ -70,14 +70,11 @@ class EtcdDatabag:
 
     def cluster_token(self):
         ''' Getter to return the unique cluster token. '''
-        if not is_leader():
-            return leader_get('token')
-
-        if not self.db.get('cluster-token'):
+        token = leader_get('token')
+        if not token and is_leader():
             token = self.id_generator()
-            self.db.set('cluster-token', token)
-            return token
-        return self.db.get('cluster-token')
+            leader_set({'cluster-token': token})
+        return token
 
     def id_generator(self, size=6):
         ''' Return a random 6 character string for use in cluster init.

--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -73,7 +73,7 @@ class EtcdDatabag:
         token = leader_get('token')
         if not token and is_leader():
             token = self.id_generator()
-            leader_set({'cluster-token': token})
+            leader_set({'token': token})
         return token
 
     def id_generator(self, size=6):


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-etcd/+bug/1843497

This fixes two problems with the etcd charm:
1. Any time a new etcd leader unit is elected, the cluster token is lost and a new one is generated in its place.
2. If an upgrade from etcd 2.3 -> 3.x has occurred in the past, then etcd is configured with a different data-dir than usual. This means that if the etcd charm ever renders a new etcd config, then the data-dir changes and all data is lost.

I tested this with two deployments. The first was a direct deployment of CK 1.16 (pre-release from edge) with these changes. I verified that the cluster token was set correctly, the charm did not attempt to move the etcd data, and that the cluster-token was reused when a new leader was elected.

With the second deployment, I started with CK 1.14 running k8s 1.12 and etcd 2.3. From there, I upgraded to etcd 3.0 and k8s 1.13, then followed the upgrade-notes for CK 1.15 (with a new note for upgrading etcd, see \<link to edit in\>). After the upgrade, I verified that all units were in a healthy state, data was not lost in the process, and the cluster-token did not change. I also verified once again that the cluster-token is preserved after a new leader is elected.