### PR TITLE
fix unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,7 @@
-dist: trusty
-sudo: required
 language: python
 python:
- - '3.5'
-
+  - "3.5"
 install:
- - pip install tox
- - sudo add-apt-repository -y ppa:juju/stable
- - sudo apt-get update
- - sudo apt-get install -y snapd charm-tools
- - sudo snap install charm --classic
-
+  - pip install tox-travis
 script:
- - mkdir -p $HOME/tmp/repo/layer
- - mkdir -p $HOME/tmp/repo/interface
- - PATH=/snap/bin:$PATH JUJU_REPOSITORY=$HOME/tmp/repo LAYER_PATH=$HOME/tmp/repo/layer INTERFACE_PATH=$HOME/tmp/repo/interface make test-convoluted
+  - tox

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,13 @@ upgrade: build
 force: build
 	juju upgrade-charm etcd --path=${JUJU_REPOSITORY}/builds/etcd --force-units
 
-test-convoluted:
-	/snap/bin/charm build -o ${HOME}/tmp -r --no-local-layers -l DEBUG
-	tox -c ${HOME}/tmp/builds/etcd/tox.ini
-	rm -rf ${HOME}/tmp
-
 clean:
-	rm -rf .tox
-	rm -f .coverage
-	rm -rf ./tmp
+	@echo "Cleaning files"
+	@rm -f .coverage .unit-state.db
+	@find . -name "*.pyc" -type f -exec rm -f '{}' \;
+	@find . -name "__pycache__" -type d -prune -exec rm -rf '{}' \;
+	@rm -rf ./.tox
+	@rm -rf ./.pytest_cache
 
 clean-all: clean
 	rm -rf ${JUJU_REPOSITORY}/builds/etcd

--- a/layer.yaml
+++ b/layer.yaml
@@ -5,12 +5,15 @@ includes:
   - 'layer:leadership'
   - 'layer:nagios'
   - 'layer:tls-client'
-  - 'layer:leadership'
   - 'layer:snap'
   - 'layer:cdk-service-kicker'
   - 'interface:etcd'
   - 'interface:etcd-proxy'
   - 'interface:nrpe-external-master'
+exclude:
+  - .coverage
+  - .tox
+  - __pycache__
 defines:
   etcd_conf_dir:
     description: Path to render etcd configuration

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,26 @@
 max-line-length = 120
 
 [tox]
-skipsdist=True
-envlist = py34, py35
-skip_missing_interpreters = True
+skipsdist = True
+envlist = lint,py3
+
+[tox:travis]
+3.5: lint,py3
 
 [testenv]
+basepython = python3
 setenv =
-  PYTHONPATH = {toxinidir}/lib
+    PYTHONPATH={toxinidir}:{toxinidir}/lib
 deps =
-    charmhelpers
-    charms.reactive
-    flake8
-    mock
-    pytest-cov
+    pyyaml
     pytest
-
+    pytest-cov
+    flake8
 commands =
-  flake8 reactive lib
-  py.test -v {posargs} --cov=lib --cov-report=term-missing
+    pytest --cov-report term-missing \
+        --cov lib --cov-fail-under 33 \
+        --tb native -s {posargs}
+
+[testenv:lint]
+envdir = {toxworkdir}/py3
+commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests {toxinidir}/unit_tests

--- a/unit_tests/test_etcdctl.py
+++ b/unit_tests/test_etcdctl.py
@@ -1,7 +1,13 @@
 import pytest
+import sys
+from unittest.mock import MagicMock, patch
 
-from etcdctl import EtcdCtl
-from mock import patch
+charms = MagicMock()
+sys.modules['charms'] = charms
+ch = MagicMock()
+sys.modules['charmhelpers.core.hookenv'] = ch.core.hookenv
+
+from etcdctl import EtcdCtl  # noqa
 
 
 class TestEtcdCtl:
@@ -10,67 +16,59 @@ class TestEtcdCtl:
     def etcdctl(self):
         return EtcdCtl()
 
-    def test_register(self):
-        with patch('etcdctl.check_output') as spcm:
-            self.etcdctl().register({'cluster_address': '127.0.0.1',
-                                     'unit_name': 'etcd0',
-                                     'management_port': '1313',
-                                     'leader_address': 'http://127.1.1.1:1212'})  # noqa
-            spcm.assert_called_with(['etcdctl',
-                                     '-C',
-                                     'http://127.1.1.1:1212',
-                                     'member',
-                                     'add',
-                                     'etcd0',
-                                     'https://127.0.0.1:1313'])  # noqa
+    def test_register(self, etcdctl):
+        with patch('etcdctl.EtcdCtl.run') as spcm:
+            etcdctl.register({'cluster_address': '127.0.0.1',
+                              'unit_name': 'etcd0',
+                              'management_port': '1313',
+                              'leader_address': 'http://127.1.1.1:1212'})
+            spcm.assert_called_with(('etcdctl -C http://127.1.1.1:1212 member '
+                                     'add etcd0 https://127.0.0.1:1313'))
 
-    def test_unregister(self):
-        with patch('etcdctl.check_output') as spcm:
-            self.etcdctl().unregister('br1212121212')
+    def test_unregister(self, etcdctl):
+        with patch('etcdctl.EtcdCtl.run') as spcm:
+            etcdctl.unregister('br1212121212')
 
-            spcm.assert_called_with(['etcdctl',
-                                     'member',
-                                     'remove',
-                                     'br1212121212'])
+            spcm.assert_called_with('etcdctl member remove br1212121212')
 
-    def test_member_list(self):
-        with patch('etcdctl.check_output') as comock:
-            comock.return_value = b'7dc8404daa2b8ca0: name=etcd22 peerURLs=https://10.113.96.220:2380 clientURLs=https://10.113.96.220:2379\n'  # noqa
-            members = self.etcdctl().member_list()
+    def test_member_list(self, etcdctl):
+        with patch('etcdctl.EtcdCtl.run') as comock:
+            comock.return_value = '7dc8404daa2b8ca0: name=etcd22 peerURLs=https://10.113.96.220:2380 clientURLs=https://10.113.96.220:2379\n'  # noqa
+            members = etcdctl.member_list()
             assert(members['etcd22']['unit_id'] == '7dc8404daa2b8ca0')
-            assert(members['etcd22']['peer_urls'] == 'https://10.113.96.220:2380')  # noqa
-            assert(members['etcd22']['client_urls'] == 'https://10.113.96.220:2379')  # noqa
+            assert(members['etcd22']['peer_urls'] == 'https://10.113.96.220:2380')
+            assert(members['etcd22']['client_urls'] == 'https://10.113.96.220:2379')
 
-    def test_member_list_with_unstarted_member(self):
+    def test_member_list_with_unstarted_member(self, etcdctl):
         ''' Validate we receive information only about members we can parse
         from the current status string '''
         # 57fa5c39949c138e[unstarted]: peerURLs=http://10.113.96.80:2380
-        # bb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379  # noqa
-        with patch('etcdctl.check_output') as comock:
-            comock.return_value = b'57fa5c39949c138e[unstarted]: peerURLs=http://10.113.96.80:2380]\nbb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379\n'  # noqa
-            members = self.etcdctl().member_list()
+        # bb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379
+        with patch('etcdctl.EtcdCtl.run') as comock:
+            comock.return_value = '57fa5c39949c138e[unstarted]: peerURLs=http://10.113.96.80:2380]\nbb0f83ebb26386f7: name=etcd9 peerURLs=https://10.113.96.178:2380 clientURLs=https://10.113.96.178:2379\n'  # noqa
+            members = etcdctl.member_list()
             assert(members['etcd9']['unit_id'] == 'bb0f83ebb26386f7')
-            assert(members['etcd9']['peer_urls'] == 'https://10.113.96.178:2380')  # noqa
-            assert(members['etcd9']['client_urls'] == 'https://10.113.96.178:2379')  # noqa
+            assert(members['etcd9']['peer_urls'] == 'https://10.113.96.178:2380')
+            assert(members['etcd9']['client_urls'] == 'https://10.113.96.178:2379')
             assert('unstarted' in members.keys())
             assert(members['unstarted']['unit_id'] == '57fa5c39949c138e')
             assert("10.113.96.80:2380" in members['unstarted']['peer_urls'])
 
-    def test_etcd_v2_version(self):
+    def test_etcd_v2_version(self, etcdctl):
         ''' Validate that etcdctl can parse versions for both etcd v2 and
         etcd v3 '''
         # Define fixtures of what we expect for the version output
-        etcdctl_2_version = b"etcdctl version 2.3.8\n"
+        etcdctl_2_version = "etcdctl version 2.3.8\n"
 
-        with patch('etcdctl.check_output') as comock:
+        with patch('etcdctl.EtcdCtl.run') as comock:
             comock.return_value = etcdctl_2_version
-            ver = self.etcdctl().version()
+            ver = etcdctl.version()
             assert(ver == '2.3.8')
 
-    def test_etcd_v3_version(self):
+    def test_etcd_v3_version(self, etcdctl):
         ''' Validate that etcdctl can parse version for etcdctl v3 '''
-        etcdctl_3_version = b"etcdctl version: 3.0.17\nAPI version: 2\n"
-        with patch('etcdctl.check_output') as comock:
+        etcdctl_3_version = "etcdctl version: 3.0.17\nAPI version: 2\n"
+        with patch('etcdctl.EtcdCtl.run') as comock:
             comock.return_value = etcdctl_3_version
-            ver = self.etcdctl().version()
+            ver = etcdctl.version()
             assert(ver == '3.0.17')


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-etcd/+bug/1846802. Travis and the unit tests were in sad shape.  Let's fix 'em:

- update travis with only whats needed for unit tests
- remove duplicate leadership layer
- exclude test bits from built artifact
- simpler tox
- fix unit tests