### PR TITLE
include cis-benchmark for etcd charm

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,7 @@
 repo: https://github.com/juju-solutions/layer-etcd.git
 includes:
   - 'layer:basic'
+  - 'layer:cis-benchmark'
   - 'layer:debug'
   - 'layer:leadership'
   - 'layer:nagios'


### PR DESCRIPTION
Include the cis-benchmark layer for the etcd. This layer brings in the cis-benchmark action for use in reporting/remediating benchmark failures.

Partially fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841262

Depends on https://github.com/juju/layer-index/pull/98