### PR TITLE
Support 3.4.x

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -85,7 +85,7 @@ def compact():
     '''
     def get_latest_revision():
         try:
-            output = CTL.run('endpoint status --write-out="json"')
+            output = CTL.run('endpoint status --write-out json')
         except subprocess.CalledProcessError as e:
             action_fail_now(
                 'Failed to determine latest revision for '

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -8,6 +8,8 @@ import sys
 
 from charms import layer
 
+from etcdctl import EtcdCtl
+
 from charmhelpers.core.hookenv import (
     action_get,
     action_set,
@@ -16,65 +18,15 @@ from charmhelpers.core.hookenv import (
 )
 
 
+CTL = EtcdCtl()
+
+
 def action_fail_now(*args, **kw):
     '''Call action_fail() and exit immediately.
 
     '''
     action_fail(*args, **kw)
     sys.exit(0)
-
-
-def etcdctl_path():
-    '''Return path to etcdctl binary.
-
-    '''
-    if os.path.isfile('/snap/bin/etcd.etcdctl'):
-        return '/snap/bin/etcd.etcdctl'
-    return 'etcdctl'
-
-
-def etcdctl(cmd, etcdctl_api='3', endpoints=None, **kw):
-    '''Call etcdctl with ``cmd`` as the command-line args.
-
-    '''
-    opts = layer.options('tls-client')
-    env = os.environ.copy()
-
-    if etcdctl_api:
-        env['ETCDCTL_API'] = etcdctl_api
-
-    etcdctl_cmd = etcdctl_path()
-
-    if endpoints is not False:
-        major, minor, _ = etcdctl_version().split('.')
-        if int(major) >= 3 and int(minor) >= 3:
-            env['ETCDCTL_CACERT'] = opts['ca_certificate_path']
-            env['ETCDCTL_CERT'] = opts['server_certificate_path']
-            env['ETCDCTL_KEY'] = opts['server_key_path']
-            if endpoints is None:
-                endpoints = 'http://127.0.0.1:4001'
-                etcdctl_cmd += ' --endpoints={}'.format(endpoints)
-        else:
-            env['ETCDCTL_CA_FILE'] = opts['ca_certificate_path']
-            env['ETCDCTL_CERT_FILE'] = opts['server_certificate_path']
-            env['ETCDCTL_KEY_FILE'] = opts['server_key_path']
-            if endpoints is None:
-                endpoints = ':4001'
-                etcdctl_cmd += ' --endpoints={}'.format(endpoints)
-
-    args = shlex.split(etcdctl_cmd) + shlex.split(cmd)
-    return subprocess.check_output(
-        args, env=env, stderr=subprocess.STDOUT, **kw).decode("utf-8").strip()
-
-
-def etcdctl_version():
-    '''Return etcdctl version.
-
-    '''
-    output = etcdctl("--version", etcdctl_api=None, endpoints=False)
-    first_line = output.split('\n')[0]
-    version = first_line.split(' ')[-1]
-    return version.strip()
 
 
 def requires_etcd_version(version_regex, human_version=None):
@@ -87,7 +39,7 @@ def requires_etcd_version(version_regex, human_version=None):
     '''
     def wrap(f):
         def wrapped_f(*args):
-            version = etcdctl_version()
+            version = CTL.version()
             if not re.match(version_regex, version):
                 required_version = human_version or version_regex
                 action_fail_now(
@@ -108,7 +60,7 @@ def alarm_disarm():
 
     '''
     try:
-        output = etcdctl('alarm disarm')
+        output = CTL.run('alarm disarm')
         action_set(dict(output=output))
     except subprocess.CalledProcessError as e:
         action_fail_now(e.output)
@@ -120,7 +72,7 @@ def alarm_list():
 
     '''
     try:
-        output = etcdctl('alarm list')
+        output = CTL.run('alarm list')
         action_set(dict(output=output))
     except subprocess.CalledProcessError as e:
         action_fail_now(e.output)
@@ -133,7 +85,7 @@ def compact():
     '''
     def get_latest_revision():
         try:
-            output = etcdctl('endpoint status --write-out="json"')
+            output = CTL.run('endpoint status --write-out="json"')
         except subprocess.CalledProcessError as e:
             action_fail_now(
                 'Failed to determine latest revision for '
@@ -150,7 +102,7 @@ def compact():
     physical = 'true' if action_get('physical') else 'false'
     command = 'compact {} --physical={}'.format(revision, physical)
     try:
-        output = etcdctl(command)
+        output = CTL.run(command)
         action_set(dict(output=output))
     except subprocess.CalledProcessError as e:
         action_fail_now(e.output)
@@ -162,7 +114,7 @@ def defrag():
 
     '''
     try:
-        output = etcdctl('defrag')
+        output = CTR.run('defrag')
         action_set(dict(output=output))
     except subprocess.CalledProcessError as e:
         action_fail_now(e.output)

--- a/actions/actions.py
+++ b/actions/actions.py
@@ -114,7 +114,7 @@ def defrag():
 
     '''
     try:
-        output = CTR.run('defrag')
+        output = CTL.run('defrag')
         action_set(dict(output=output))
     except subprocess.CalledProcessError as e:
         action_fail_now(e.output)

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ options:
     description: Port to run the ETCD Management service
   channel:
     type: string
-    default: 2.3/stable
+    default: auto
     description: The snap channel to install from
   snapd_refresh:
     default: "max"

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -1,7 +1,6 @@
 from charms import layer
 from charmhelpers.core.hookenv import log
 from subprocess import CalledProcessError
-from shlex import split
 from subprocess import check_output
 import os
 
@@ -139,8 +138,6 @@ class EtcdCtl:
         ca_path = opts['ca_certificate_path']
         crt_path = opts['server_certificate_path']
         key_path = opts['server_key_path']
-
-        #major, _, _ = self.version().split('.')
 
         if api == 3:
             env['ETCDCTL_API'] = '3'

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -74,7 +74,7 @@ def get_target_etcd_channel():
         if snap.is_installed('etcd'):
             return False
         else:
-            return '3.3/edge'
+            return '3.3/stable'
     else:
         return channel
 

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -743,9 +743,12 @@ def render_config(bag=None):
 
 def etcd_version():
     ''' This method surfaces the version from etcdctl '''
-    cmd = ['/snap/bin/etcd.etcdctl', '--version']
+    cmd = ['/snap/bin/etcd.etcdctl', 'version']
     try:
-        raw_output = check_output(cmd)
+        raw_output = check_output(
+            cmd,
+            env={'ETCDCTL_API': '3'}
+        )
         lines = raw_output.split(b'\n')
         for line in lines:
             if b'etcdctl version' in line:

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -365,7 +365,7 @@ def register_node_with_leader(cluster):
         # we can register from scratch.
         peer_url = 'https://%s:%s' % (bag.cluster_address, bag.management_port)
         members = etcdctl.member_list(leader_address)
-        for member_name, member in members.items():
+        for _, member in members.items():
             if member['peer_urls'] == peer_url:
                 log('Found member that matches our peer URL. Unregistering...')
                 etcdctl.unregister(member['unit_id'], leader_address)

--- a/templates/etcd3.conf
+++ b/templates/etcd3.conf
@@ -3,6 +3,10 @@
 # Human-readable name for this member.
 name: {{ unit_name }}
 
+# Enable API v2 support for flannel and
+# certain charm executions.
+enable-v2: true
+
 # Path to the data directory.
 data-dir: {{ etcd_data_dir }}
 


### PR DESCRIPTION
I think it's time to do some major surgery as 3.4.x has more compatibility issues when not enforcing `ETCDCTL_API=3`, but this breaks a lot of `etcdctl.py`.  I think `etcdctl.py` should be the sole place that `etcdctl` is called (means deleting from `actions.py`).  This can then handle the logic for sorting between API 2 and 3, allowing us to enforce it based on version.

Will take longer than initially anticipated, but we're just kicking the can down the road otherwise.

Fixes: https://bugs.launchpad.net/charm-etcd/+bug/1852676