### PR TITLE
Fixing execution of `render_default_user_ssl_exports` before etcd is installed

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -329,7 +329,7 @@ def install_etcd():
     if channel:
         snap.install('etcd', channel=channel, classic=False)
 
-    set_state('etcd.installed')
+    set_state('snap.installed.etcd')
 
 
 @when('snap.installed.etcd')
@@ -526,7 +526,6 @@ def tls_update():
 
     # ensure that certs are re-echoed to the db relations
     remove_state('etcd.ssl.placed')
-
     remove_state('tls_client.ca.written')
     remove_state('tls_client.server.certificate.written')
     remove_state('tls_client.client.certificate.written')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -8,6 +8,7 @@ from charms.reactive import endpoint_from_flag
 from charms.reactive import when
 from charms.reactive import when_any
 from charms.reactive import when_not
+from charms.reactive import is_state
 from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import hook
@@ -149,7 +150,7 @@ def remove_states():
     # stale state cleanup (pre rev6)
     remove_state('etcd.tls.secured')
     remove_state('etcd.ssl.placed')
-    remove_state('etcd.pillowmints')
+    remove_state('etcd.ssl.exported')
 
 
 @when('snap.installed.etcd')
@@ -308,7 +309,6 @@ def snap_install():
     snap.install('core')
     if channel:
         snap.install('etcd', channel=channel, classic=False)
-    remove_state('etcd.pillowmints')
 
 
 @when('etcd.ssl.placed')
@@ -318,7 +318,7 @@ def install_etcd():
     resources are provided attempt to install from the archive only on the
     16.04 (xenial) series. '''
 
-    if charms.reactive.is_state('etcd.installed'):
+    if is_state('etcd.installed'):
         msg = 'Manual upgrade required. run-action snap-upgrade.'
         status_set('blocked', msg)
         return
@@ -328,6 +328,8 @@ def install_etcd():
     channel = get_target_etcd_channel()
     if channel:
         snap.install('etcd', channel=channel, classic=False)
+
+    set_state('etcd.installed')
 
 
 @when('snap.installed.etcd')
@@ -530,7 +532,8 @@ def tls_update():
     remove_state('tls_client.client.certificate.written')
 
 
-@when_not('etcd.pillowmints')
+@when('snap.installed.etcd')
+@when_not('etcd.ssl.exported')
 def render_default_user_ssl_exports():
     ''' Add secure credentials to default user environment configs,
     transparently adding TLS '''
@@ -559,7 +562,8 @@ def render_default_user_ssl_exports():
         fp.writelines(evars)
     with open('/root/.bash_aliases', 'w') as fp:
         fp.writelines(evars)
-    set_state('etcd.pillowmints')
+
+    set_state('etcd.ssl.exported')
 
 
 @hook('cluster-relation-broken')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -309,6 +309,7 @@ def snap_install():
     snap.install('core')
     if channel:
         snap.install('etcd', channel=channel, classic=False)
+        remove_state('etcd.ssl.exported')
 
 
 @when('etcd.ssl.placed')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -329,8 +329,6 @@ def install_etcd():
     if channel:
         snap.install('etcd', channel=channel, classic=False)
 
-    set_state('snap.installed.etcd')
-
 
 @when('snap.installed.etcd')
 @when_not('etcd.service-restart.configured')


### PR DESCRIPTION
Re. https://bugs.launchpad.net/charm-etcd/+bug/1861483

Have tested this with CK stable and edge.  Have tested an etcd snap upgrade as well as etcd charm upgrade.

Will hold to test with the exact failure case on the bug report.