### PR TITLE
Update nrpe when upgrading charm

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -697,9 +697,13 @@ def initial_nrpe_config(nagios=None):
 
 @when('etcd.installed')
 @when('nrpe-external-master.available')
-@when_not('etcd.nrpe.configured')
 @when_any('config.changed.nagios_context',
           'config.changed.nagios_servicegroups')
+def force_update_nrpe_config():
+    remove_state('etcd.nrpe.configured')
+
+
+@when_not('etcd.nrpe.configured')
 def update_nrpe_config(unused=None):
     # List of systemd services that will be checked
     services = ('snap.etcd.etcd',)

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -154,6 +154,7 @@ def remove_states():
     remove_state('etcd.tls.secured')
     remove_state('etcd.ssl.placed')
     remove_state('etcd.ssl.exported')
+    remove_state('etcd.nrpe.configured')
 
 
 @hook('pre-series-upgrade')
@@ -696,6 +697,7 @@ def initial_nrpe_config(nagios=None):
 
 @when('etcd.installed')
 @when('nrpe-external-master.available')
+@when_not('etcd.nrpe.configured')
 @when_any('config.changed.nagios_context',
           'config.changed.nagios_servicegroups')
 def update_nrpe_config(unused=None):
@@ -745,6 +747,7 @@ def update_nrpe_config(unused=None):
     )
 
     nrpe_setup.write()
+    set_state('etcd.nrpe.configured')
 
 
 @when_not('nrpe-external-master.available')


### PR DESCRIPTION
I noticed when upgrading the charm that this was missing and that the etcd-alarms check wasn't configured.

Fixes: https://bugs.launchpad.net/charm-etcd/+bug/1876287