### PR TITLE
Fix update_nrpe_config being called too early

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -695,14 +695,14 @@ def initial_nrpe_config(nagios=None):
     update_nrpe_config(nagios)
 
 
-@when('etcd.installed')
-@when('nrpe-external-master.available')
 @when_any('config.changed.nagios_context',
           'config.changed.nagios_servicegroups')
 def force_update_nrpe_config():
     remove_state('etcd.nrpe.configured')
 
 
+@when('etcd.installed')
+@when('nrpe-external-master.available')
 @when_not('etcd.nrpe.configured')
 def update_nrpe_config(unused=None):
     # List of systemd services that will be checked


### PR DESCRIPTION
The change in PR #172 should have left the affirmative conditions on the `update_nrpe_config` handler but moved them to the `force_update_nrpe_config` handler, leaving the original handler to only be guarded by a negative assertion.  Thus, it is called far too early in the charm lifecycle.

Fixes [lp:1881126](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1881126)