### PR TITLE
Port netaddr pin fix from layer:basic

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,4 @@
 charms.templating.jinja2>=1.0.0,<2.0.0
+
+# pin netaddr to avoid pulling importlib-resources from above lib
+netaddr<=0.7.19


### PR DESCRIPTION
Porting juju-solutions/layer-basic#179 in to this charm as well because the charms.templating.jinja2 requirement brings charm-helpers and the un-pinned netaddr back in.  This is a temporary work-around until charm-build can be updated to not handle each layer's wheelhouse in isolation (or we switch to the new framework).