### PR TITLE
Update etcd default channel to 3.4/stable

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -77,7 +77,7 @@ def get_target_etcd_channel():
         if snap.is_installed('etcd'):
             return False
         else:
-            return '3.3/stable'
+            return '3.4/stable'
     else:
         return channel
 


### PR DESCRIPTION
I noticed that the charm default doesn't match what's in our bundles ([link](https://github.com/charmed-kubernetes/bundle/blob/master/fragments/k8s/cdk/bundle.yaml#L44)). I assume we want to update this.