### PR TITLE
Etcd action to recover from majority failure

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -61,3 +61,10 @@ restore:
         Dont backup any existing data, and skip directly to data restoration.
 recover:
   description: Recover from a majority failure in Etcd cluster.
+  params:
+    timeout:
+      type: integer
+      default: 600
+      description: |
+        How long to wait for the Etcd cluster to restart and search logs
+        for configuration change.

--- a/actions.yaml
+++ b/actions.yaml
@@ -59,3 +59,5 @@ restore:
       default: True
       description: |
         Dont backup any existing data, and skip directly to data restoration.
+recover:
+  description: Recover from a majority failure in Etcd cluster.

--- a/actions/recover
+++ b/actions/recover
@@ -39,5 +39,10 @@ do
   sleep 1
 done
 
+# if $LOADED_CONF is still zero, the timeout has been reached
+if [ $LOADED_CONF -eq 0 ]; then
+  action-fail "Timeout reached. Failed to find 'configuration load' from logs."
+fi
+
 # Step 3
 sed -i 's/force-new-cluster.*/force-new-cluster: false/g' $ETCD_CONFIG

--- a/actions/recover
+++ b/actions/recover
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -ex
+
+# Recover from a majority failure in an etcd cluster
+# This action should be run after failed units are removed.
+# The basic flow is as follows:
+# 1. Change etcd config file to start a new cluster from
+#    scratch which allows new units to be added to cluster
+# 2. Restart the etcd service (which also starts a new cluster)
+# 3. Change config back to how it started
+# After these steps, added units will join the cluster as expected
+
+ETCD_CONFIG=/var/snap/etcd/common/etcd.conf.yml
+START_TIME=$(date +%s)
+
+if [ ! -f "$ETCD_CONFIG" ]; then
+  action-fail "Etcd config file does not exist: $ETCD_CONFIG"
+  exit
+fi
+
+# Step 1
+sed -i 's/force-new-cluster.*/force-new-cluster: true/g' $ETCD_CONFIG
+
+# Step 2
+/usr/sbin/service snap.etcd.etcd restart
+
+# wait for the updated config to be used in the restart process
+# before changing 'force-new-cluster' back to false
+LOADED_CONFIG_TIME=0
+while [ $START_TIME -gt $LOADED_CONFIG_TIME ]
+do
+  # if no line is found that matches, this will return a null string
+  # example log time format: "2020-08-06 15:08:29.985406"
+  # this time will be converted to a format parsable by 'date' command
+  LOADED_CONFIG_STR=$(journalctl -o cat -u snap.etcd.etcd.service |
+                      grep "etcdmain: Loading server configuration" |
+                      tail -1 |
+                      awk '{print $1 "T" $2}')
+  if [ ! -z $LOADED_CONFIG_STR ]; then
+    LOADED_CONFIG_TIME=$(date -d $LOADED_CONFIG_STR +%s)
+  fi
+sleep 1
+done
+
+# Step 3
+sed -i 's/force-new-cluster.*/force-new-cluster: false/g' $ETCD_CONFIG

--- a/actions/recover
+++ b/actions/recover
@@ -12,7 +12,8 @@ set -ex
 # After these steps, added units will join the cluster as expected
 
 ETCD_CONFIG=/var/snap/etcd/common/etcd.conf.yml
-START_TIME=$(date +%s)
+START=$(date +%s)  # epoch format
+TIMEOUT=600 # 10 minute timeout
 
 if [ ! -f "$ETCD_CONFIG" ]; then
   action-fail "Etcd config file does not exist: $ETCD_CONFIG"
@@ -27,20 +28,15 @@ sed -i 's/force-new-cluster.*/force-new-cluster: true/g' $ETCD_CONFIG
 
 # wait for the updated config to be used in the restart process
 # before changing 'force-new-cluster' back to false
-LOADED_CONFIG_TIME=0
-while [ $START_TIME -gt $LOADED_CONFIG_TIME ]
+# if $TIMEOUT seconds have passed, break from the loop
+LOADED_CONF=0
+while [ $LOADED_CONF -eq 0 ] && [ $(($(date +%s) - $START)) -lt $TIMEOUT ]
 do
-  # if no line is found that matches, this will return a null string
-  # example log time format: "2020-08-06 15:08:29.985406"
-  # this time will be converted to a format parsable by 'date' command
-  LOADED_CONFIG_STR=$(journalctl -o cat -u snap.etcd.etcd.service |
-                      grep "etcdmain: Loading server configuration" |
-                      tail -1 |
-                      awk '{print $1 "T" $2}')
-  if [ ! -z $LOADED_CONFIG_STR ]; then
-    LOADED_CONFIG_TIME=$(date -d $LOADED_CONFIG_STR +%s)
-  fi
-sleep 1
+  # continue looping until logs load server configuration
+  LOADED_CONF=$(journalctl -o short -u snap.etcd.etcd.service --since=@$START \
+                | grep "Loading server configuration" \
+                | wc -l)
+  sleep 1
 done
 
 # Step 3

--- a/actions/recover
+++ b/actions/recover
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Recover from a majority failure in an etcd cluster
 # This action should be run after failed units are removed.
@@ -12,8 +12,8 @@ set -ex
 # After these steps, added units will join the cluster as expected
 
 ETCD_CONFIG=/var/snap/etcd/common/etcd.conf.yml
-START=$(date +%s)  # epoch format
-TIMEOUT=600 # 10 minute timeout
+START=$(date +%s) # script start time in epoch format
+TIMEOUT=600 # the allowable time to run script
 
 if [ ! -f "$ETCD_CONFIG" ]; then
   action-fail "Etcd config file does not exist: $ETCD_CONFIG"
@@ -32,7 +32,7 @@ sed -i 's/force-new-cluster.*/force-new-cluster: true/g' $ETCD_CONFIG
 LOADED_CONF=0
 while [ $LOADED_CONF -eq 0 ] && [ $(($(date +%s) - $START)) -lt $TIMEOUT ]
 do
-  # continue looping until logs load server configuration
+  # continue looping until etcd service loads configuration file
   LOADED_CONF=$(journalctl -o short -u snap.etcd.etcd.service --since=@$START \
                 | grep "Loading server configuration" \
                 | wc -l)

--- a/actions/recover
+++ b/actions/recover
@@ -13,7 +13,7 @@ set -e
 
 ETCD_CONFIG=/var/snap/etcd/common/etcd.conf.yml
 START=$(date +%s) # script start time in epoch format
-TIMEOUT=600 # the allowable time to run script
+TIMEOUT=$(action-get timeout) # the allowable time to run script
 
 if [ ! -f "$ETCD_CONFIG" ]; then
   action-fail "Etcd config file does not exist: $ETCD_CONFIG"


### PR DESCRIPTION
Bug: [1]

A few questions before I convert this to a real PR:

1. I wanted some way of waiting for the configuration to be loaded before writing over the changed config parameter `force-new-cluster`. Waiting a sufficiently high number of seconds would also work, but it didn't seem like super robust solution to me. Does this make sense?
2. I hard coded a timeout, but this could be a parameter to the action. Does this seem necessary? Through my testing, I didn't encounter any situation where we were even remotely close to the timeout step, but I figured I'd add it just in case there's some weird reason the other loop condition is not met. (Changing log text in the future?).
3. `ETCD_CONFIG` (line 14) just matches what we see in [2] - is there a better way of defining this?

[1] https://bugs.launchpad.net/charm-etcd/+bug/1842332
[2] https://github.com/charmed-kubernetes/layer-etcd/blob/aca040b46ac80e97da8ea3135b46216cf6bb854c/layer.yaml#L23