### PR TITLE
Fix v2 API being disabled after upgrade to 3.4

### DIFF
--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -65,7 +65,7 @@ class EtcdDatabag:
         self.server_key = key_path
 
         # Cluster concerns
-        self.cluster = self.db.get('etcd.cluster')
+        self.cluster = self.db.get('etcd.cluster', '')
         self.token = self.cluster_token()
         self.cluster_state = 'existing'
 

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -39,6 +39,7 @@ from etcd_lib import get_ingress_address, get_ingress_addresses
 from shlex import split
 from subprocess import check_call
 from subprocess import check_output
+from subprocess import CalledProcessError
 from shutil import copyfile
 
 import os
@@ -155,6 +156,8 @@ def remove_states():
     remove_state('etcd.ssl.placed')
     remove_state('etcd.ssl.exported')
     remove_state('etcd.nrpe.configured')
+    # force a config re-render in case template changed
+    set_state('etcd.rerender-config')
 
 
 @hook('pre-series-upgrade')
@@ -201,8 +204,6 @@ def leader_config_changed():
             log(etcdctl.member_update(members[unit_name]['unit_id'], url))
         # Render just the leaders configuration with the new values.
         render_config()
-        # Close the previous client port and open the new one.
-        close_open_ports()
         address = get_ingress_address('cluster')
         leader_set({'leader_address':
                    get_connection_string([address],
@@ -217,23 +218,26 @@ def leader_config_changed():
 def follower_config_changed():
     ''' Follower units need to render the configuration file, close and open
     ports, and restart the etcd service. '''
-    bag = EtcdDatabag()
-    log('Rendering defaults file for {0}'.format(bag.unit_name))
-    # Render the follower's configuration with the new values.
-    render_config()
-    # Close the previous client port and open the new one.
-    close_open_ports()
+    set_state('etcd.rerender-config')
 
 
 @when('snap.installed.etcd')
 @when('config.changed.bind_to_all_interfaces')
 @when_not('upgrade.series.in-progress')
 def bind_to_all_interfaces_changed():
+    set_state('etcd.rerender-config')
+
+
+@when('etcd.rerender-config')
+@when_not('upgrade.series.in-progress')
+def rerender_config():
     ''' Config must be updated and service restarted '''
     bag = EtcdDatabag()
     log('Rendering config file for {0}'.format(bag.unit_name))
     render_config()
-    host.service_restart(bag.etcd_daemon)
+    if host.service_running(bag.etcd_daemon):
+        host.service_restart(bag.etcd_daemon)
+    set_app_version()
 
 
 @when('cluster.joined')
@@ -319,6 +323,12 @@ def send_cluster_details(proxy):
         cluster.append(peer_string)
 
     proxy.set_cluster_string(','.join(cluster))
+
+
+@when('config.changed.channel')
+def channel_changed():
+    ''' Ensure that the config is updated if the channel changes. '''
+    set_state('etcd.rerender-config')
 
 
 @when('config.changed.channel')
@@ -564,7 +574,12 @@ def render_default_user_ssl_exports():
     client_crt = opts['client_certificate_path']
     client_key = opts['client_key_path']
 
-    major, minor, _ = etcd_version().split('.')
+    etcd_ver = etcd_version()
+    if etcd_ver == 'n/a':
+        hookenv.log('Unable to determine version format for etcd SSL config',
+                    level=hookenv.ERROR)
+        return
+    major, minor, _ = etcd_ver.split('.')
 
     if int(major) >= 3 and int(minor) >= 3:
         evars = [
@@ -816,37 +831,50 @@ def render_config(bag=None):
 
     move_etcd_data_to_standard_location()
 
+    v2_conf_path = "{}/etcd.conf".format(bag.etcd_conf_dir)
+    v3_conf_path = "{}/etcd.conf.yml".format(bag.etcd_conf_dir)
+
     # probe for 2.x compatibility
     if etcd_version().startswith('2.'):
-        conf_path = "{}/etcd.conf".format(bag.etcd_conf_dir)
-        render('etcd2.conf', conf_path, bag.__dict__, owner='root',
+        render('etcd2.conf', v2_conf_path, bag.__dict__, owner='root',
                group='root')
     # default to 3.x template behavior
     else:
-        conf_path = "{}/etcd.conf.yml".format(bag.etcd_conf_dir)
-        render('etcd3.conf', conf_path, bag.__dict__, owner='root',
+        render('etcd3.conf', v3_conf_path, bag.__dict__, owner='root',
                group='root')
+        if os.path.exists(v2_conf_path):
+            # v3 will fail if the v2 config is left in place
+            os.remove(v2_conf_path)
     # Close the previous client port and open the new one.
+    close_open_ports()
+    remove_state('etcd.rerender-config')
 
 
 def etcd_version():
     ''' This method surfaces the version from etcdctl '''
-    cmd = ['/snap/bin/etcd.etcdctl', 'version']
+    raw_output = None
     try:
+        # try v3
         raw_output = check_output(
-            cmd,
+            ['/snap/bin/etcd.etcdctl', 'version'],
             env={'ETCDCTL_API': '3'}
-        )
-        lines = raw_output.split(b'\n')
-        for line in lines:
-            if b'etcdctl version' in line:
-                # etcdctl version: 3.0.17
-                # Strip and massage the output
-                version = str(line, 'utf-8')
-                version = version.split('version')[-1].replace(':', '').strip()
+        ).decode('utf-8').strip()
+        if "No help topic for 'version'" in raw_output:
+            # handle v2
+            raw_output = check_output(
+                ['/snap/bin/etcd.etcdctl', '--version']
+            ).decode('utf-8').strip()
+        for line in raw_output.splitlines():
+            if 'etcdctl version' in line:
+                # "etcdctl version: 3.0.17" or "etcdctl version 2.3.8"
+                version = line.split()[-1]
                 return version
+        hookenv.log('Unable to find etcd version: {}'.format(raw_output),
+                    level=hookenv.ERROR)
         return 'n/a'
-    except: # NOQA
+    except (ValueError, CalledProcessError):
+        hookenv.log('Failed to get etcd version:\n'
+                    '{}'.format(traceback.format_exc()), level=hookenv.ERROR)
         return 'n/a'
 
 


### PR DESCRIPTION
Ensure that the config file is re-rendered when upgrading from the CK 1.16 release of the Etcd charm and then switching the channel to 3.4.

Fixes [lp:1892380](https://bugs.launchpad.net/charm-etcd/+bug/1892380)