### PR TITLE
Fix initial-cluster-state resetting to "existing" during deployment

### DIFF
--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -67,12 +67,17 @@ class EtcdDatabag:
         # Cluster concerns
         self.cluster = self.db.get('etcd.cluster', '')
         self.token = self.cluster_token()
-        self.cluster_state = 'existing'
+        self.cluster_state = self.db.get('etcd.cluster-state', 'existing')
 
     def set_cluster(self, value):
         ''' Set the cluster string for peer registration '''
         self.cluster = value
         self.db.set('etcd.cluster', value)
+
+    def set_cluster_state(self, value):
+        ''' Set the cluster state '''
+        self.cluster_state = value
+        self.db.set('etcd.cluster-state', value)
 
     def cluster_token(self):
         ''' Getter to return the unique cluster token. '''

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -448,7 +448,7 @@ def initialize_new_leader():
     etcd, and set the leadership data so the followers can join this one. '''
     bag = EtcdDatabag()
     bag.token = bag.token
-    bag.cluster_state = 'new'
+    bag.set_cluster_state('new')
     address = get_ingress_address('cluster')
     cluster_connection_string = get_connection_string([address],
                                                       bag.management_port)


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-etcd/+bug/1867544

This fixes the etcd service on the leader failing to start with
```
cannot fetch cluster info from peer urls: could not retrieve cluster information from the given URLs
```

This happens when the [initialize_new_leader](https://github.com/charmed-kubernetes/layer-etcd/blob/84932ee12bab9d19b733334b7ade25ba0871bb1b/reactive/etcd.py#L446) handler is followed by [tls_update](https://github.com/charmed-kubernetes/layer-etcd/blob/84932ee12bab9d19b733334b7ade25ba0871bb1b/reactive/etcd.py#L550) that re-renders the config with `initial-cluster-state=existing` and restarts the etcd service before etcd has properly bootstrapped.

The fix is to store initial-cluster-state in unitdata so that it is preserved in future re-renders of the config.