### PR TITLE
changed etcd snapshot default keys-version to v3

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -45,7 +45,7 @@ snapshot:
       description: Location to save the etcd snapshot.
     keys-version:
       type: string
-      default: 'v2'
+      default: 'v3'
       description: Version of keys to snapshoot. Allowed values 'v3' or 'v2'.
 restore:
   description: Restore an etcd cluster's data from a snapshot tarball.


### PR DESCRIPTION
Etcd 3.x has two APIs with two separate databases: etcdv2 and etcdv3.
The latest version of Kubernetes (1.13+) will use the etcdv3 API,
however, the default value of the snapshot action is still using v2,
which use database etcdv2.

Fixes: https://bugs.launchpad.net/charm-etcd/+bug/1840933