### PR TITLE
Fix package-client-credentials action for new versions

### DIFF
--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -5,9 +5,9 @@
 source ~/.bash_aliases
 mkdir -p etcd_credentials
 
-cp $ETCDCTL_CERT_FILE etcd_credentials/client.crt
-cp $ETCDCTL_KEY_FILE etcd_credentials/client.key
-cp $ETCDCTL_CA_FILE etcd_credentials/ca.crt
+cp $ETCDCTL_CERT etcd_credentials/client.crt
+cp $ETCDCTL_KEY etcd_credentials/client.key
+cp $ETCDCTL_CACERT etcd_credentials/ca.crt
 
 # Render a README heredoc
 cat << EOF > etcd_credentials/README.txt
@@ -26,9 +26,9 @@ practice to leave it firewalled from the world unless you have need of an
 exposed etcd endpoint.
 
   juju expose etcd
-  export ETCDCTL_KEY_FILE=$(pwd)/client.key
-  export ETCDCTL_CERT_FILE=$(pwd)/client.crt
-  export ETCDCTL_CA_FILE=$(pwd)/ca.crt
+  export ETCDCTL_KEY=$(pwd)/client.key
+  export ETCDCTL_CERT=$(pwd)/client.crt
+  export ETCDCTL_CACERT=$(pwd)/ca.crt
   export ETCDCTL_ENDPOINT=https://$(unit-get public-address):2379
   etcdctl member list
 

--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -29,7 +29,7 @@ exposed etcd endpoint.
   export ETCDCTL_KEY=$(pwd)/client.key
   export ETCDCTL_CERT=$(pwd)/client.crt
   export ETCDCTL_CACERT=$(pwd)/ca.crt
-  export ETCDCTL_ENDPOINT=https://$(unit-get public-address):2379
+  export ETCDCTL_ENDPOINTS=https://$(unit-get public-address):2379
   etcdctl member list
 
 If you have any trouble regarding connecting to your Etcd cluster, don't


### PR DESCRIPTION
I am quite new to all this, so apoligies if I don't understand the problem exactly

I was having trouble exporting client keys using the `package-client-credentials` action. It was failing with the output:

```
unit-etcd-0:
  UnitId: etcd/0
  id: "6"
  results:
    Stderr: |
      cp: missing destination file operand after 'etcd_credentials/client.crt'
      Try 'cp --help' for more information.
      cp: missing destination file operand after 'etcd_credentials/client.key'
      Try 'cp --help' for more information.
      cp: missing destination file operand after 'etcd_credentials/ca.crt'
      Try 'cp --help' for more information.
  status: completed
  timing:
    completed: 2021-01-09 22:44:26 +0000 UTC
    enqueued: 2021-01-09 22:44:06 +0000 UTC
    started: 2021-01-09 22:44:26 +0000 UTC
```

And the output tarball didn't contain any credentials.

I tracked it down to a discrepency in the environment variable naming. In code there is a version check and current versions use new names: https://github.com/charmed-kubernetes/layer-etcd/blob/fe3911e7e4fcf81a3046e02596cf34159a6a69b2/reactive/etcd.py#L584-L595

But the action script was never updated. I'm not sure how to make it change by version, but I think if it has to be one it should be the current version.

Thanks!