### PR TITLE
Fix health action

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -120,12 +120,24 @@ def defrag():
         action_fail_now(e.output)
 
 
+def health():
+    '''Call etcdctl cluster-health
+
+    '''
+    try:
+        output = CTL.cluster_health(True)
+        action_set(dict(output=output))
+    except subprocess.CalledProcessError as e:
+        action_fail_now(e.output)
+
+
 if __name__ == '__main__':
     ACTIONS = {
         'alarm-disarm': alarm_disarm,
         'alarm-list': alarm_list,
         'compact': compact,
         'defrag': defrag,
+        'health': health,
     }
 
     action = action_name()

--- a/actions/health
+++ b/actions/health
@@ -1,7 +1,1 @@
-#!/bin/bash
-
-set -e
-source ~/.bash_aliases
-OUT=$(/snap/bin/etcd.etcdctl -C http://127.0.0.1:4001 cluster-health)
-
-action-set result-map.message="${OUT}"
+actions.py

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -114,12 +114,14 @@ class EtcdCtl:
             log('Failed to update member {}'.format(unit_id), 'WARNING')
         return out
 
-    def cluster_health(self):
+    def cluster_health(self, output_only=False):
         ''' Returns the output of etcdctl cluster-health as a python dict
         organized by topical information with detailed unit output '''
         health = {}
         try:
             out = self.run('cluster-health', endpoints=False, api=2)
+            if output_only:
+                return out
             health_output = out.strip('\n').split('\n')
             health['status'] = health_output[-1]
             health['units'] = health_output[0:-2]


### PR DESCRIPTION
Health action is currently implemented using a bash script that
queries etcdv2's cluster-health, but it is currently failing
because the API version is not being defined by the script, so
on newer versions of etcd it fails since it defaults to v3.

This patch fixes it by changing the action to use the EtcdCtl
wrapper class.

Fixes: https://bugs.launchpad.net/charm-etcd/+bug/1911437