### PR TITLE
Check env vars and use the correct ones for package-client-credentials

### DIFF
--- a/actions/package-client-credentials
+++ b/actions/package-client-credentials
@@ -5,10 +5,15 @@
 source ~/.bash_aliases
 mkdir -p etcd_credentials
 
-cp $ETCDCTL_CERT_FILE etcd_credentials/client.crt
-cp $ETCDCTL_KEY_FILE etcd_credentials/client.key
-cp $ETCDCTL_CA_FILE etcd_credentials/ca.crt
-
+if [ -z ${ETCDCTL_CERT_FILE} ]; then
+    cp $ETCDCTL_CERT etcd_credentials/client.crt
+    cp $ETCDCTL_KEY etcd_credentials/client.key
+    cp $ETCDCTL_CACERT etcd_credentials/ca.crt
+else
+    cp $ETCDCTL_CERT_FILE etcd_credentials/client.crt
+    cp $ETCDCTL_KEY_FILE etcd_credentials/client.key
+    cp $ETCDCTL_CA_FILE etcd_credentials/ca.crt
+fi
 # Render a README heredoc
 cat << EOF > etcd_credentials/README.txt
 # ETCD Credentials Package


### PR DESCRIPTION
etcd version 3.3 introduced a change in env variables that broke the package-client-credentials action. This PR will check to see if the old variables are present (thus <3.3) and use them, or use the new vars if not.

Fixes: https://bugs.launchpad.net/charm-etcd/+bug/1914788