### PR TITLE
Fixed etcd charm status on unhealhy state

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -133,7 +133,10 @@ def check_cluster_health():
     bp = "{0} with {1} known peer{2}"
     status_message = bp.format(unit_health, peers, 's' if peers != 1 else '')
 
-    status.active(status_message)
+    if unit_health == "UnHealthy":
+        status.blocked(status_message)
+    else:
+        status.active(status_message)
 
 
 @when('snap.installed.etcd')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -133,7 +133,7 @@ def check_cluster_health():
     bp = "{0} with {1} known peer{2}"
     status_message = bp.format(unit_health, peers, 's' if peers != 1 else '')
 
-    if unit_health == "UnHealthy":
+    if unit_health in ["UnHealthy", 'Errored']:
         status.blocked(status_message)
     else:
         status.active(status_message)


### PR DESCRIPTION
Charms needs to set blocked status if the cluster is unhealthy. This way, using [juju-lint](https://charmhub.io/juju-lint) we will be able to receive alerts based on the blocked state and act proactively on fixing errors.