### PR TITLE
Adding try and except to get public address

### DIFF
--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -1,5 +1,4 @@
 from charms import layer
-from charmhelpers.core.hookenv import unit_get
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import is_leader
 from charmhelpers.core.hookenv import leader_get, leader_set
@@ -41,7 +40,6 @@ class EtcdDatabag:
         self.port = config('port')
         self.management_port = config('management_port')
         # Live polled properties
-        self.public_address = unit_get('public-address')
         self.cluster_address = get_ingress_address('cluster')
         self.db_address = get_ingress_address('db')
         self.unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '')

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -152,9 +152,16 @@ def missing_relation_notice():
 
 @when('certificates.available')
 def prepare_tls_certificates(tls):
-    common_name = hookenv.unit_public_ip()
+    try:
+        common_name = hookenv.unit_public_ip()
+    except (CalledProcessError, KeyError, IndexError) as e:
+        msg = 'Public address not available yet'
+        hookenv.log(msg, hookenv.WARNING)
+        hookenv.log(e, hookenv.WARNING)
+        return
+
     sans = set()
-    sans.add(hookenv.unit_public_ip())
+    sans.add(common_name)
     sans.update(get_ingress_addresses('db'))
     sans.update(get_ingress_addresses('cluster'))
     sans.add(socket.gethostname())


### PR DESCRIPTION
This PR attempts to solve the [bug/1924780](https://bugs.launchpad.net/charm-easyrsa/+bug/1924780) where the hook fails when trying to get the public address.

Charms should be resilient in case the public IP is not ready.