### PR TITLE
Add 127.0.0.1 to the tls cert

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -169,6 +169,7 @@ def prepare_tls_certificates(tls):
     sans.update(get_ingress_addresses("db"))
     sans.update(get_ingress_addresses("cluster"))
     sans.add(socket.gethostname())
+    sans.add("127.0.0.1")
 
     # add cluster peers as alt names when present
     cluster = endpoint_from_flag("cluster.joined")


### PR DESCRIPTION
This allows using etcd clients (such as etcdctl)
to securely connect to the etcd server
in cases where they they must connect via the localhost address.
