### PR TITLE
Remove ubuntu user access to etcd tls cert files

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -570,15 +570,12 @@ def set_snapd_timer():
 def tls_state_control():
     """This state represents all the complexity of handling the TLS certs.
     instead of stacking decorators, this state condenses it into a single
-    state we can gate on before progressing with secure setup. Also handles
-    ensuring users of the system can access the TLS certificates"""
+    state we can gate on before progressing with secure setup."""
 
     bag = EtcdDatabag()
     if not os.path.isdir(bag.etcd_conf_dir):
         hookenv.log("Waiting for etcd conf creation.")
         return
-    cmd = ["chown", "-R", "root:ubuntu", bag.etcd_conf_dir]
-    check_call(cmd)
     set_state("etcd.ssl.placed")
 
 
@@ -608,7 +605,7 @@ def tls_update():
 @when("snap.installed.etcd")
 @when_not("etcd.ssl.exported")
 def render_default_user_ssl_exports():
-    """Add secure credentials to default user environment configs,
+    """Add secure credentials to default user environment config for root,
     transparently adding TLS"""
     opts = layer.options("tls-client")
 
@@ -638,8 +635,6 @@ def render_default_user_ssl_exports():
             "export ETCDCTL_CA_FILE={}\n".format(ca_path),
         ]
 
-    with open("/home/ubuntu/.bash_aliases", "w") as fp:
-        fp.writelines(evars)
     with open("/root/.bash_aliases", "w") as fp:
         fp.writelines(evars)
 


### PR DESCRIPTION
Remove ubuntu user access to etcd tls cert files

This is for general security hardening.
It means the ubuntu user will no longer have access
to the sensitive tls cert, key, and ca files for etcd
(ie. the files in /var/snap/etcd/common/ ).

An implication of this is that the `etcdctl` command
will no longer be configured or usable for the ubuntu user.
In cases where users previously accessed the shell
on an etcd unit to run etcdctl commands as the ubuntu user,
they will now need to run as root from an interactive shell
(interactive because the config is set in .bash_aliases).

This also means that for any cases where users manually copied
(via ssh or scripts) the cert files from an etcd unit,
they will now need to use sudo.

Interestingly, etcdctl from the local etcd unit with tls
has been broken anyway,
due to 127.0.0.1 not being included in the etcd certs.
See https://github.com/charmed-kubernetes/layer-etcd/pull/204

Closes-Bug: https://bugs.launchpad.net/charm-etcd/+bug/1997531
