### PR TITLE
delay sharing details until etcd is registered

### DIFF
--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -281,6 +281,7 @@ def rerender_config():
 
 
 @when("cluster.joined")
+@when("etcd.registered")
 def set_db_ingress_address(cluster):
     """Send db ingress address to peers on the cluster relation"""
     address = get_ingress_address("db")

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -291,6 +291,7 @@ def set_db_ingress_address(cluster):
 @when("db.connected")
 @when("etcd.ssl.placed")
 @when("cluster.joined")
+@when("etcd.registered")
 def send_cluster_connection_details(cluster, db):
     """Need to set the cluster connection string and
     the client key and certificate on the relation object."""
@@ -319,6 +320,7 @@ def send_cluster_connection_details(cluster, db):
 @when("db.connected")
 @when("etcd.ssl.placed")
 @when_not("cluster.joined")
+@when("etcd.registered")
 def send_single_connection_details(db):
     """ """
     cert = read_tls_cert("client.crt")
@@ -889,6 +891,7 @@ def remove_nrpe_config(nagios=None):
 
 
 @when("endpoint.prometheus.joined", "leadership.is_leader", "certificates.ca.available")
+@when("etcd.registered")
 def register_prometheus_jobs():
     # This function is not guarded with `when_not("prometheus.configured")`
     # to account for possible changes of etcd units IP adresses and for when


### PR DESCRIPTION
For etcd: Units are sending cluster connection details before etcd is ready. It should delay sending cluster connection details until after etcd has successfully registered

[LP#2008267](https://bugs.launchpad.net/charm-calico/+bug/2008267)