### PR TITLE
Charm to support ipv6 addresses in urls within templates and relation data

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -1,12 +1,8 @@
 #!/usr/local/sbin/charm-env python3
 
-import os
 import re
-import shlex
 import subprocess
 import sys
-
-from charms import layer
 
 from etcdctl import EtcdCtl
 

--- a/lib/etcd_databag.py
+++ b/lib/etcd_databag.py
@@ -5,7 +5,7 @@ from charmhelpers.core.hookenv import leader_get, leader_set
 from charmhelpers.core import unitdata
 from charms.reactive import is_state
 from etcd_lib import get_ingress_address
-from etcd_lib import get_bind_address
+from etcd_lib import get_bind_address, build_uri
 
 import string
 import random
@@ -36,6 +36,7 @@ class EtcdDatabag:
 
     def __init__(self):
         self.db = unitdata.kv()
+        self.build_uri = build_uri
         self.cluster_bind_address = self.get_bind_address("cluster")
         self.db_bind_address = self.get_bind_address("db")
         self.port = config("port")

--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -38,9 +38,13 @@ def get_ingress_addresses(endpoint_name):
 
 
 def get_ingress_address(endpoint_name):
-    """Returns an ingress-address belonging to the named endpoint, if
-    available. Falls back to private-address if necessary."""
-    return get_ingress_addresses(endpoint_name)[0]
+    """Returns an ingress-address belonging to the named endpoint.
+
+    * Sort addresses by ipv4 first, then ipv6 next
+    * Falls back to private-address if necessary.
+    """
+    all_addrs = get_ingress_addresses(endpoint_name)
+    return sorted(all_addrs, key=lambda i: ip_address(i).version)[0]
 
 
 def get_bind_address(endpoint_name):
@@ -48,8 +52,10 @@ def get_bind_address(endpoint_name):
     belonging to the named endpoint, if available.
     Falls back to private-address if necessary.
 
-        @param endpoint_name the endpoint from where taking the
-        bind address
+    * Sort addresses by ipv4 first, then ipv6 next
+
+    @param endpoint_name the endpoint from where taking the
+    bind address
     """
     try:
         data = network_get(endpoint_name)
@@ -63,11 +69,11 @@ def get_bind_address(endpoint_name):
     # interfacename: ens5
     # addresses:
     # - hostname: ""
-    #     address: 172.31.5.4
-    #     cidr: 172.31.0.0/20
+    #   address: 172.31.5.4
+    #   cidr: 172.31.0.0/20
     # - hostname: ""
-    #     address: 172.31.5.4
-    #     cidr: 172.31.0.0/20
+    #   address: 172.31.5.4
+    #   cidr: 172.31.0.0/20
     # - macaddress: 8a:32:d7:8d:f6:9a
     # interfacename: fan-252
     # addresses:
@@ -80,12 +86,21 @@ def get_bind_address(endpoint_name):
     # - 172.31.5.4
     # - 172.31.5.4
     # - 252.5.4.1
-    if "bind-addresses" in data:
-        bind_addresses = data["bind-addresses"]
-        if len(bind_addresses) > 0:
-            if "addresses" in bind_addresses[0]:
-                if len(bind_addresses[0]["addresses"]) > 0:
-                    return bind_addresses[0]["addresses"][0]["address"]
+    interfaces = data.get("bind-addresses", [])
+    addresses = []
+
+    if interfaces:
+        addresses = sorted(
+            [
+                ip_address(addr["address"])
+                for ifc in interfaces
+                for addr in ifc.get("addresses", [])
+                if "address" in addr
+            ],
+            key=lambda addr: addr.version,
+        )
+    if addresses:
+        return str(addresses[0])
 
     return unit_private_ip()
 

--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -1,3 +1,5 @@
+from ipaddress import ip_address
+
 from charmhelpers.contrib.templating.jinja import render
 from charmhelpers.core.hookenv import (
     network_get,
@@ -7,6 +9,18 @@ from charmhelpers.core.hookenv import (
 import json
 
 GRAFANA_DASHBOARD_FILE = "grafana_dashboard.json.j2"
+
+
+def build_uri(schema, address, port) -> str:
+    """Build uris with ipv6 addresses in square-brakets []."""
+    try:
+        address = ip_address(address)
+    except ValueError:
+        pass
+    else:
+        if address.version == 6:
+            address = f"[{address}]"
+    return f"{schema}://{address}:{port}"
 
 
 def get_ingress_addresses(endpoint_name):

--- a/lib/etcd_lib.py
+++ b/lib/etcd_lib.py
@@ -66,18 +66,18 @@ def get_bind_address(endpoint_name):
     #
     # bind-addresses:
     # - macaddress: 02:d0:9e:31:d9:e0
-    # interfacename: ens5
-    # addresses:
-    # - hostname: ""
-    #   address: 172.31.5.4
-    #   cidr: 172.31.0.0/20
-    # - hostname: ""
-    #   address: 172.31.5.4
-    #   cidr: 172.31.0.0/20
+    #   interfacename: ens5
+    #   addresses:
+    #   - hostname: ""
+    #     address: 172.31.5.4
+    #     cidr: 172.31.0.0/20
+    #   - hostname: ""
+    #     address: 172.31.5.4
+    #     cidr: 172.31.0.0/20
     # - macaddress: 8a:32:d7:8d:f6:9a
-    # interfacename: fan-252
-    # addresses:
-    # - hostname: ""
+    #   interfacename: fan-252
+    #   addresses:
+    #   - hostname: ""
     #     address: 252.5.4.1
     #     cidr: 252.0.0.0/12
     # egress-subnets:

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -4,6 +4,7 @@ from subprocess import CalledProcessError
 from subprocess import check_output
 from subprocess import STDOUT
 import os
+from etcd_lib import build_uri
 
 
 def etcdctl_command():
@@ -205,6 +206,6 @@ def get_connection_string(members, port, protocol="https"):
     port and protocol (defaults to https)"""
     connections = []
     for address in members:
-        connections.append("{}://{}:{}".format(protocol, address, port))
+        connections.append(build_uri(protocol, address, port))
     connection_string = ",".join(connections)
     return connection_string

--- a/reactive/etcd.py
+++ b/reactive/etcd.py
@@ -42,6 +42,7 @@ from etcdctl import EtcdCtl
 from etcdctl import get_connection_string
 from etcd_databag import EtcdDatabag
 from etcd_lib import (
+    build_uri,
     get_ingress_address,
     get_ingress_addresses,
     render_grafana_dashboard,
@@ -460,7 +461,7 @@ def register_node_with_leader(cluster):
     try:
         # Check if we are already registered. Unregister ourselves if we are so
         # we can register from scratch.
-        peer_url = "https://%s:%s" % (bag.cluster_address, bag.management_port)
+        peer_url = build_uri("https", bag.cluster_address, bag.management_port)
         members = etcdctl.member_list(leader_address)
         for _, member in members.items():
             if member["peer_urls"] == peer_url:

--- a/templates/etcd2.conf
+++ b/templates/etcd2.conf
@@ -1,10 +1,10 @@
 # This file is rendered by Juju, manual edits will not be persisted
 ETCD_DATA_DIR={{ etcd_data_dir }}/{{ unit_name }}.etcd
 ETCD_NAME={{ unit_name }}
-ETCD_ADVERTISE_CLIENT_URLS="https://{{ db_address }}:{{ port }}"
-ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://{{ db_bind_address }}:{{ port }}"
-ETCD_LISTEN_PEER_URLS="https://{{ cluster_bind_address }}:{{ management_port }}"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="https://{{ cluster_address }}:{{ management_port }}"
+ETCD_ADVERTISE_CLIENT_URLS="{{ build_uri('https', db_address, port) }}"
+ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,{{ build_uri('https', db_bind_address, port) }}"
+ETCD_LISTEN_PEER_URLS="{{ build_uri('https', cluster_bind_address, management_port) }}"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="{{ build_uri('https', cluster_address, management_port) }}"
 {% if cluster %}
 ETCD_INITIAL_CLUSTER="{{ cluster }}"
 ETCD_INITIAL_CLUSTER_STATE={{ cluster_state }}

--- a/templates/etcd3.conf
+++ b/templates/etcd3.conf
@@ -28,9 +28,10 @@ election-timeout: 1000
 quota-backend-bytes: 0
 
 # List of comma separated URLs to listen on for peer traffic.
-listen-peer-urls: https://{{ cluster_bind_address }}:{{ management_port}}
+
+listen-peer-urls: {{ build_uri('https', cluster_bind_address, management_port) }}
 # List of comma separated URLs to listen on for client traffic.
-listen-client-urls: http://127.0.0.1:4001,https://{{ db_bind_address }}:{{ port }}
+listen-client-urls: http://127.0.0.1:4001,{{ build_uri('https', db_bind_address, port) }}
 
 # Maximum number of snapshot files to retain (0 is unlimited).
 max-snapshots: 5
@@ -43,11 +44,12 @@ cors:
 
 # List of this member's peer URLs to advertise to the rest of the cluster.
 # The URLs needed to be a comma-separated list.
-initial-advertise-peer-urls: https://{{ cluster_address }}:{{ management_port }}
+
+initial-advertise-peer-urls: {{ build_uri('https', cluster_address, management_port) }}
 
 # List of this member's client URLs to advertise to the public.
 # The URLs needed to be a comma-separated list.
-advertise-client-urls: https://{{ db_address }}:{{ port }}
+advertise-client-urls: {{ build_uri('https', db_address, port) }}
 
 # Discovery URL used to bootstrap the cluster.
 discovery: 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import charms.unit_test
 
-
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module("charms.leadership")
+

--- a/tests/unit/lib/test_etcd_databag.py
+++ b/tests/unit/lib/test_etcd_databag.py
@@ -1,0 +1,74 @@
+from jinja2 import FileSystemLoader, Environment
+from unittest import mock
+import pytest
+
+from charms.unit_test import MockKV
+import reactive.etcd
+import etcd_databag
+
+
+@pytest.fixture
+def config():
+    kv = MockKV()
+    reactive.etcd.config.reset_mock()
+    reactive.etcd.config.side_effect = kv.get
+    reactive.etcd.config.set = kv.set
+    return reactive.etcd.config
+
+
+@pytest.fixture
+def bind_address(config):
+    config.set("bind_to_all_interfaces", False)
+    IP = dict(cluster="1.1.1.1", db="2001:0dc8::0001")
+    with mock.patch(
+        "etcd_databag.get_bind_address", side_effect=lambda name: IP.get(name)
+    ) as mocked:
+        yield mocked
+
+
+@pytest.fixture
+def ingress_address():
+    IP = dict(cluster="2.2.2.2", db="4001:0084::0001")
+    with mock.patch(
+        "etcd_databag.get_ingress_address", side_effect=lambda name: IP.get(name)
+    ) as mocked:
+        yield mocked
+
+
+def test_render_etcd2(
+    config,
+    bind_address,
+    ingress_address,
+):
+    config.set("management_port", 1234)
+    config.set("port", 5678)
+    bag = etcd_databag.EtcdDatabag()
+    template_env = Environment(loader=FileSystemLoader("templates"))
+    config = template_env.get_template("etcd2.conf").render(bag.__dict__)
+    lines = config.splitlines()
+    assert 'ETCD_ADVERTISE_CLIENT_URLS="https://[4001:84::1]:5678"' in lines
+    assert (
+        'ETCD_LISTEN_CLIENT_URLS="http://127.0.0.1:4001,https://[2001:dc8::1]:5678"'
+        in lines
+    )
+    assert 'ETCD_LISTEN_PEER_URLS="https://1.1.1.1:1234"' in lines
+    assert 'ETCD_INITIAL_ADVERTISE_PEER_URLS="https://2.2.2.2:1234"' in lines
+
+
+def test_render_etcd3(
+    config,
+    bind_address,
+    ingress_address,
+):
+    config.set("management_port", 1234)
+    config.set("port", 5678)
+    bag = etcd_databag.EtcdDatabag()
+    template_env = Environment(loader=FileSystemLoader("templates"))
+    config = template_env.get_template("etcd3.conf").render(bag.__dict__)
+    lines = config.splitlines()
+    assert "advertise-client-urls: https://[4001:84::1]:5678" in lines
+    assert (
+        "listen-client-urls: http://127.0.0.1:4001,https://[2001:dc8::1]:5678" in lines
+    )
+    assert "listen-peer-urls: https://1.1.1.1:1234" in lines
+    assert "initial-advertise-peer-urls: https://2.2.2.2:1234" in lines

--- a/tests/unit/lib/test_etcd_lib.py
+++ b/tests/unit/lib/test_etcd_lib.py
@@ -1,9 +1,11 @@
 from typing import Any
+from unittest import mock
 
 from charmhelpers.contrib.templating import jinja
+import charmhelpers.core.hookenv as hookenv
 import pytest
 
-from etcd_lib import render_grafana_dashboard, build_uri
+from etcd_lib import build_uri, get_bind_address, render_grafana_dashboard
 
 
 def test_render_grafana_dashboard():
@@ -33,3 +35,60 @@ def test_render_grafana_dashboard():
 )
 def test_build_uri(src: Any, result: str):
     assert build_uri("https", src, 8080) == result
+
+
+@pytest.fixture
+def unit_private_ip():
+    hookenv.unit_private_ip.reset_mock()
+    return hookenv.unit_private_ip
+
+
+def test_get_bind_address_fails_network_get(unit_private_ip):
+    with mock.patch("etcd_lib.network_get", side_effect=NotImplementedError):
+        assert get_bind_address("test") == unit_private_ip.return_value
+    unit_private_ip.assert_called_once_with()
+
+
+def test_get_bind_address_empty_bind_address(unit_private_ip):
+    with mock.patch("etcd_lib.network_get", return_value={}):
+        assert get_bind_address("test") == unit_private_ip.return_value
+    unit_private_ip.assert_called_once_with()
+
+
+def test_get_bind_address_picks_v4_first(unit_private_ip):
+    ipv4 = "1.2.3.4"
+    bind_data = {
+        "bind-addresses": [
+            {
+                "macaddress": "02:d0:9e:31:d9:e0",
+                "interfacename": "ens5",
+                "addresses": [
+                    {
+                        "hostname": "",
+                        "address": "2002::1234:abcd:ffff:c0a8:101",
+                        "cidr": "2002::1234:abcd:ffff:c0a8:101/64",
+                    },
+                    {"hostname": "", "address": ipv4, "cidr": f"{ipv4}/20"},
+                ],
+            }
+        ]
+    }
+    with mock.patch("etcd_lib.network_get", return_value=bind_data):
+        assert get_bind_address("test") == ipv4
+    unit_private_ip.assert_not_called()
+
+
+def test_get_bind_address_picks_v6(unit_private_ip):
+    ipv6 = "2002::1234:abcd:ffff:c0a8:101"
+    bind_data = {
+        "bind-addresses": [
+            {
+                "macaddress": "",
+                "interfacename": "ens5",
+                "addresses": [{"hostname": "", "address": ipv6, "cidr": f"{ipv6}/64"}],
+            }
+        ]
+    }
+    with mock.patch("etcd_lib.network_get", return_value=bind_data):
+        assert get_bind_address("test") == ipv6
+    unit_private_ip.assert_not_called()

--- a/tests/unit/lib/test_etcd_lib.py
+++ b/tests/unit/lib/test_etcd_lib.py
@@ -1,6 +1,9 @@
-from charmhelpers.contrib.templating import jinja
+from typing import Any
 
-from etcd_lib import render_grafana_dashboard
+from charmhelpers.contrib.templating import jinja
+import pytest
+
+from etcd_lib import render_grafana_dashboard, build_uri
 
 
 def test_render_grafana_dashboard():
@@ -18,3 +21,15 @@ def test_render_grafana_dashboard():
     rendered_dashboard = render_grafana_dashboard(datasource)
 
     assert rendered_dashboard == expected_dashboard
+
+
+@pytest.mark.parametrize(
+    "src,result",
+    [
+        ("1.2.3.4", "https://1.2.3.4:8080"),
+        ("2001:0db8::0001", "https://[2001:db8::1]:8080"),
+        ("my.host.io", "https://my.host.io:8080"),
+    ],
+)
+def test_build_uri(src: Any, result: str):
+    assert build_uri("https", src, 8080) == result

--- a/tests/unit/test_etcdctl.py
+++ b/tests/unit/test_etcdctl.py
@@ -3,6 +3,8 @@ from unittest.mock import patch, MagicMock
 
 import reactive.etcd
 
+import etcd_lib
+
 from etcdctl import (
     EtcdCtl,
     etcdctl_command,
@@ -161,7 +163,12 @@ class TestEtcdCtl:
         )
         reactive.etcd.set_flag.assert_called_with("prometheus.configured")
 
-    def test_series_upgrade(self):
+    def test_series_upgrade(self, mocker):
+        mocker.patch.object(
+            etcd_lib,
+            "get_ingress_addresses",
+            return_value=["10.0.0.1", "2001:0dc8::0001"],
+        )
         assert host.service_pause.call_count == 0
         assert host.service_resume.call_count == 0
         assert status.blocked.call_count == 0
@@ -188,8 +195,15 @@ class TestEtcdCtl:
     @patch("shutil.rmtree")
     @patch("os.path.join")
     @patch("time.sleep")
-    def test_force_rejoin(self, sleep, path_join, rmtree, path_exists, register_node):
+    def test_force_rejoin(
+        self, sleep, path_join, rmtree, path_exists, register_node, mocker
+    ):
         """Test that force_rejoin performs required steps."""
+        mocker.patch.object(
+            etcd_lib,
+            "get_ingress_addresses",
+            return_value=["10.0.0.1", "2001:0dc8::0001"],
+        )
         data_dir = "/foo/bar"
         path_exists.return_value = True
         path_join.return_value = data_dir

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
 [testenv:unit]
 deps =
     pyyaml
+    jinja2
     pytest
     pytest-mock
     pytest-cov


### PR DESCRIPTION
Address issues 
* [LP#1913348](https://bugs.launchpad.net/charm-etcd/+bug/1913348)
* [LP#1947034](https://bugs.launchpad.net/charm-etcd/+bug/1947034)

urls with ipv6 addresses cannot be rendered as `https://${address}:${port}` because the address itself contains colons

instead each URL must be rendered as `https://[${address}]:${port}`

this PR creates a new `build_uri` method and uses it everywhere previous urls were being created. 

It takes care to ensure that
* ipv4 addresses remain the same, 
* ipv6 addresses are handled correctly
* anything else is handled the same as a ipv4