### PR TITLE
Redirect nagios cron output to tee

### DIFF
--- a/templates/check_etcd-alarms.cron
+++ b/templates/check_etcd-alarms.cron
@@ -1,2 +1,2 @@
 # check_etcd_alarms
-* * * * * root [ -x /snap/bin/etcdctl ] && ETCDCTL_API=3 /snap/bin/etcdctl --endpoints=127.0.0.1:4001 alarm list > /var/lib/nagios/etcd-alarm-list.txt
+* * * * * root [ -x /snap/bin/etcdctl ] && ETCDCTL_API=3 /snap/bin/etcdctl --endpoints=127.0.0.1:4001 alarm list 2>&1| tee /var/lib/nagios/etcd-alarm-list.txt > /dev/null


### PR DESCRIPTION
If etcd is running inside LXD, directly piping the output to the /var/lib/nagios/etcd-alarm-list.txt file won't be allowed by apparmor.

The aim of this patch is to redirect the output through tee as this will be allowed and alarms will be written normally, we will also supress output to stdout in order not to flood the local mta as the errors should be picked up by nagios.

Fixes: LP#2021950