### PR TITLE
[LP#2096820] Don't push stderr through stdout when running etcdctl

### DIFF
--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -177,7 +177,7 @@ class EtcdCtl:
             command.insert(2, endpoints)
 
         try:
-            proc = run(command, env=env, check=True, capture_output=True)
+            proc = run(command, env=env, check=True, capture_output=True, text=True)
         except CalledProcessError as e:
             log(command, "ERROR")
             log(env, "ERROR")
@@ -188,8 +188,8 @@ class EtcdCtl:
         if proc.stderr:
             log(command, "WARNING")
             log(env, "WARNING")
-            log(proc.stderr.decode("utf-8"), "WARNING")
-        return proc.stdout.decode("utf-8")
+            log(proc.stderr, "WARNING")
+        return proc.stdout
 
     def version(self):
         """Return the version of etcdctl"""

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -185,7 +185,7 @@ class EtcdCtl:
             log(e.stderr, "ERROR")
             raise EtcdCtl.CommandFailed() from e
 
-        if proc.stderr:
+        if proc.stderr.strip():
             log(command, "WARNING")
             log(env, "WARNING")
             log(proc.stderr, "WARNING")

--- a/lib/etcdctl.py
+++ b/lib/etcdctl.py
@@ -1,8 +1,7 @@
 from charms import layer
 from charmhelpers.core.hookenv import log
 from subprocess import CalledProcessError
-from subprocess import check_output
-from subprocess import STDOUT
+from subprocess import check_output, run
 from typing import Optional
 import os
 from etcd_lib import build_uri
@@ -178,13 +177,19 @@ class EtcdCtl:
             command.insert(2, endpoints)
 
         try:
-            return check_output(command, env=env, stderr=STDOUT).decode("utf-8")
+            proc = run(command, env=env, check=True, capture_output=True)
         except CalledProcessError as e:
             log(command, "ERROR")
             log(env, "ERROR")
             log(e.stdout, "ERROR")
             log(e.stderr, "ERROR")
             raise EtcdCtl.CommandFailed() from e
+
+        if proc.stderr:
+            log(command, "WARNING")
+            log(env, "WARNING")
+            log(proc.stderr.decode("utf-8"), "WARNING")
+        return proc.stdout.decode("utf-8")
 
     def version(self):
         """Return the version of etcdctl"""

--- a/tests/unit/test_etcdctl.py
+++ b/tests/unit/test_etcdctl.py
@@ -115,15 +115,23 @@ class TestEtcdCtl:
     def test_etcdctl_environment_with_version_2(self, etcdctl):
         """Validate that environment gets set correctly
         spoiler alert; it shouldn't be set when passing --version"""
-        with patch("etcdctl.check_output") as comock:
-            etcdctl.run("member list", api=2)
+        with patch("etcdctl.run") as comock:
+            comock.return_value.stdout = expected = (
+                b"""
+4f24ee16c889f6c1: name=etcd20 peerURLs=https://10.113.96.197:2380 clientURLs=https://10.113.96.197:2379  # noqa
+edc04bb81479d7e8: name=etcd21 peerURLs=https://10.113.96.243:2380 clientURLs=https://10.113.96.243:2379  # noqa
+edc0dsa81479d7e8[unstarted]: peerURLs=https://10.113.96.124:2380  # noqa""".strip()
+            )
+            comock.stderr = """Warning: something happened"""
+            out = etcdctl.run("member list", api=2)
             api_version = comock.call_args[1].get("env").get("ETCDCTL_API")
             assert api_version == "2"
+            assert out == expected.decode()
 
     def test_etcdctl_environment_with_version_3(self, etcdctl):
         """Validate that environment gets set correctly
         spoiler alert; it shouldn't be set when passing --version"""
-        with patch("etcdctl.check_output") as comock:
+        with patch("etcdctl.run") as comock:
             etcdctl.run("member list", api=3)
             api_version = comock.call_args[1].get("env").get("ETCDCTL_API")
             assert api_version == "3"

--- a/tests/unit/test_etcdctl.py
+++ b/tests/unit/test_etcdctl.py
@@ -117,7 +117,7 @@ class TestEtcdCtl:
         spoiler alert; it shouldn't be set when passing --version"""
         with patch("etcdctl.run") as comock:
             comock.return_value.stdout = expected = (
-                b"""
+                """
 4f24ee16c889f6c1: name=etcd20 peerURLs=https://10.113.96.197:2380 clientURLs=https://10.113.96.197:2379  # noqa
 edc04bb81479d7e8: name=etcd21 peerURLs=https://10.113.96.243:2380 clientURLs=https://10.113.96.243:2379  # noqa
 edc0dsa81479d7e8[unstarted]: peerURLs=https://10.113.96.124:2380  # noqa""".strip()
@@ -126,7 +126,7 @@ edc0dsa81479d7e8[unstarted]: peerURLs=https://10.113.96.124:2380  # noqa""".stri
             out = etcdctl.run("member list", api=2)
             api_version = comock.call_args[1].get("env").get("ETCDCTL_API")
             assert api_version == "2"
-            assert out == expected.decode()
+            assert out == expected
 
     def test_etcdctl_environment_with_version_3(self, etcdctl):
         """Validate that environment gets set correctly


### PR DESCRIPTION
### Overview
Addresses [LP#2096820](https://bugs.launchpad.net/charm-etcd/+bug/2096820)

Simply -- better handling of stdout, not letting it be polluted with stderr when a etcdctl command completes successfully with warnings in stderr.