### PR TITLE
unblocking launchpad builds of charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,7 +21,9 @@ parts:
     - https://raw.githubusercontent.com/charmed-kubernetes/layer-index/main/
     - --debug
     - --force
-    build-snaps: 
+    build-packages:
+    - python3-dev
+    build-snaps:
     - charm/3.x/stable
     build-environment:
     - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/

--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -7,4 +7,4 @@ function cleanup { rm -rf "$build_dir"; }
 trap cleanup EXIT
 
 charm-build src --build-dir "$build_dir" --debug
-pip install -f "$build_dir/$charm/wheelhouse" --no-index --no-cache-dir "$build_dir"/etcd/wheelhouse/*
+pip install -f "$build_dir/$charm/wheelhouse" --no-index --no-cache-dir "$build_dir"/$charm/wheelhouse/*


### PR DESCRIPTION
### Overview
After merging #216, launchpad builds of this charm are failing with missing `Python.h` from `python3-dev` package. 
