### PR TITLE
chore: mark optional provides endpoints as optional in metadata

### DIFF
--- a/src/metadata.yaml
+++ b/src/metadata.yaml
@@ -16,10 +16,13 @@ provides:
     interface: etcd
   proxy:
     interface: etcd-proxy
+    optional: true
   prometheus:
     interface: prometheus-manual
+    optional: true
   grafana:
     interface: grafana-dashboard
+    optional: true
 peers:
   cluster:
     interface: etcd


### PR DESCRIPTION
Mark `proxy`, `prometheus`, and `grafana` (provides) as `optional: true`. Each is gated on `@when("endpoint.*.joined")`; etcd operates normally with zero consumers on any of them. `db` is left required as there is no reason to deploy etcd without a consumer.